### PR TITLE
Codebase Review bugfixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+# Git commit workflow
+
+- Never run `git commit` unless the user explicitly asks for it in that turn. Preparing a diff, drafting a commit message, and staging files is fine at any time — running the actual `git commit` command is not, until the user says to commit.
+- Every commit made by Claude must include a `Co-Authored-By: Claude <model-name> <noreply@anthropic.com>` trailer in the commit message (e.g. `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>`), using a HEREDOC so the message formats correctly. Do not omit this trailer even when the user's request is a short "please commit this."
+- If a change was worked on across a model switch within the same session, include a `Co-Authored-By` trailer for each model that contributed, not just the one active when the commit happens.
+
+# Fix scope
+
+- When a bug report floats a bigger, speculative fix (a new concept/feature/column) alongside a smaller fix that's consistent with existing patterns in the codebase, don't default to the bigger one just because it was mentioned last or most elaborately. Surface the scope as an explicit choice (e.g. via a clarifying question) before planning. Expect the smaller, consistent-with-existing-patterns fix to usually be preferred.
+- A same-sized adjacent bug found while fixing another one is fine to fold in and flag in the summary. An architecturally bigger one (needs a structural change, not a local fix) should be surfaced as an explicit scope question before proceeding, even mid-task.
+
+# Testing
+
+- Don't monkeypatch core/foundational objects (e.g. `pd.DataFrame`) just to force coverage of an effectively-unreachable or trivial code path. If reaching a branch requires that kind of risk, it's usually not worth testing -- skip it, even if the patch would clean up via fixture teardown.
+- For a fix addressing a subtle bug (wrong direction, silent no-op, wrong pruning order — not a trivial typo), prove the new tests actually catch the regression: temporarily revert the production change, confirm they fail, then restore it. "Tests pass" alone isn't proof a fix is correct.
+
+# Deferred work
+
+- When a fix needs a structural change rather than a local one and gets deliberately deferred, write a structured handover (history/context, the bug with a concrete reproduction, the proposed fix design and trade-offs, implementation notes, testing guidance) rather than cramming it into the current session.
+
+# Reporting
+
+- State uncertainty plainly rather than asserting with more confidence than the evidence supports. Distinguish what you've directly verified from what you're inferring — e.g. "confirmed via code inspection, but couldn't trigger through the public API" rather than presenting an inference as settled fact.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,22 @@
 # Git commit workflow
 
-- Never run `git commit` unless the user explicitly asks for it in that turn. Preparing a diff, drafting a commit message, and staging files is fine at any time — running the actual `git commit` command is not, until the user says to commit.
-- Every commit made by Claude must include a `Co-Authored-By: Claude <model-name> <noreply@anthropic.com>` trailer in the commit message (e.g. `Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>`), using a HEREDOC so the message formats correctly. Do not omit this trailer even when the user's request is a short "please commit this."
-- If a change was worked on across a model switch within the same session, include a `Co-Authored-By` trailer for each model that contributed, not just the one active when the commit happens.
+- Never run `git commit` unless the user explicitly asks for it that turn. Drafting a message and staging files is fine anytime; committing is not.
+- Every commit must include a `Co-Authored-By: Claude <model-name> <noreply@anthropic.com>` trailer (via HEREDOC), even for a short "please commit this." If multiple models contributed this session, include a trailer for each.
 
 # Fix scope
 
-- When a bug report floats a bigger, speculative fix (a new concept/feature/column) alongside a smaller fix that's consistent with existing patterns in the codebase, don't default to the bigger one just because it was mentioned last or most elaborately. Surface the scope as an explicit choice (e.g. via a clarifying question) before planning. Expect the smaller, consistent-with-existing-patterns fix to usually be preferred.
-- A same-sized adjacent bug found while fixing another one is fine to fold in and flag in the summary. An architecturally bigger one (needs a structural change, not a local fix) should be surfaced as an explicit scope question before proceeding, even mid-task.
+- If a bug report floats a bigger, speculative fix alongside a smaller one consistent with existing patterns, don't default to the bigger one just because it was mentioned last. Surface the choice explicitly before planning — the smaller fix usually wins.
+- A same-sized adjacent bug found in passing is fine to fold in and flag in the summary. A structurally bigger one needs an explicit scope question first, even mid-task.
 
 # Testing
 
-- Don't monkeypatch core/foundational objects (e.g. `pd.DataFrame`) just to force coverage of an effectively-unreachable or trivial code path. If reaching a branch requires that kind of risk, it's usually not worth testing -- skip it, even if the patch would clean up via fixture teardown.
-- For a fix addressing a subtle bug (wrong direction, silent no-op, wrong pruning order — not a trivial typo), prove the new tests actually catch the regression: temporarily revert the production change, confirm they fail, then restore it. "Tests pass" alone isn't proof a fix is correct.
+- Don't monkeypatch core objects (e.g. `pd.DataFrame`) just to cover an unreachable or trivial branch — skip it instead.
+- For fixes to subtle bugs (wrong direction, silent no-op, wrong ordering), prove the new test catches the regression: revert the fix, confirm it fails, then restore. "Tests pass" alone isn't proof.
 
 # Deferred work
 
-- When a fix needs a structural change rather than a local one and gets deliberately deferred, write a structured handover (history/context, the bug with a concrete reproduction, the proposed fix design and trade-offs, implementation notes, testing guidance) rather than cramming it into the current session.
+- When a fix needs a structural change and gets deferred, write a handover: context, a concrete repro, the proposed design and trade-offs, implementation notes, and testing guidance.
 
 # Reporting
 
-- State uncertainty plainly rather than asserting with more confidence than the evidence supports. Distinguish what you've directly verified from what you're inferring — e.g. "confirmed via code inspection, but couldn't trigger through the public API" rather than presenting an inference as settled fact.
+- State uncertainty plainly. Distinguish what's directly verified from what's inferred, e.g. "confirmed via code inspection, but couldn't trigger through the public API."

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,24 @@
+## v0.4.1
+
+- Bugfixes for equity weighting
+    - Fix `weights={"equity": ...}` giving the *most* weight to the least deprived regions instead of the most deprived, under both direction encodings
+    - Rename `add_equity_data()`'s ambiguous `direction` parameter to `disadvantaged_end` (`direction` is kept as a deprecated alias and now raises a `FutureWarning`); also fix its default to match the documented DLUHC decile convention
+    - Fix incomplete equity data silently dropping demand points from every metric (max, weighted/unweighted averages, coverage), not just equity-specific ones; `solve()` now raises a clear error when `"equity"` is weighted over incomplete data
+- Bugfixes for search strategies (greedy / GRASP / brute-force)
+    - Fix `max_value_cutoff` being silently ignored by greedy and GRASP (only brute-force enforced it)
+    - Fix `required_sites_col` being ignored by GRASP, and greedy crashing when two or more sites were required
+    - Fix `keep_best_n`/`keep_worst_n` being effectively random for `mclp`, and pruning before cost weighting was applied for brute-force
+    - Fix a cost-weighting no-op silently inverting `mclp`'s search in greedy, GRASP, and the shared final sort, so the worst combination could be returned as "best"
+    - Fix GRASP's `min_sites_different` diversity threshold using the wrong formula, accepting solutions as more diverse than requested
+    - Add a clear error when more sites are required than `p` allows for brute-force (greedy/GRASP already had this)
+- Bugfixes for `solve()` and single-solution evaluation
+    - `solve()` now rejects unknown keyword arguments instead of silently swallowing typos
+    - Fix mclp's missing-demand warning exemption not applying when `objectives` is passed as a list
+    - Fix weight keys (`"demand"`/`"equity"`) not being truly case-insensitive, and a related unreachable error for genuinely unrecognised weight keys
+    - Fix `evaluate_single_solution_single_objective` silently accepting partially-invalid, duplicate, or empty `site_indices`/`site_names`
+- Fix equity plot titles rendering raw `np.int64(...)` reprs instead of plain site numbers; add `show_site_names=True` to list site names instead
+- Add a backtest suite and document test conventions in `tests/README.md`
+
 ## v0.4.0
 
 - Add support for setting site costs

--- a/lokigi/mixins/site_eda.py
+++ b/lokigi/mixins/site_eda.py
@@ -201,7 +201,9 @@ class SiteProblemHotspotCalculationMixin:
                 df[df_merge_col].isin(ctx.demand_data[ctx._demand_data_id_col].unique())
             ]
 
-            if ctx._equity_data_direction == "higher_is_worse":
+            # Analysis columns are oriented so higher = more advantaged;
+            # negate when the disadvantaged end of the scale is the high end.
+            if ctx._equity_data_disadvantaged_end == "high":
                 analysis_col = f"_{df_col}_analysis"
                 df[analysis_col] = -df[df_col]
                 df_col = analysis_col
@@ -220,7 +222,7 @@ class SiteProblemHotspotCalculationMixin:
             ]
 
             equity_col = ctx._equity_data_equity_col
-            if ctx._equity_data_direction == "higher_is_worse":
+            if ctx._equity_data_disadvantaged_end == "high":
                 equity_df["_equity_directed"] = -equity_df[equity_col]
             else:
                 equity_df["_equity_directed"] = equity_df[equity_col]
@@ -407,7 +409,7 @@ class SiteSolutionHotspotCalculationMixin(SiteProblemHotspotCalculationMixin):
     - ``"travel_demand"`` : combined minimum travel time + demand.
     - ``"travel_equity"`` : combined minimum travel time + equity (IMD etc.).
 
-    In all travel-time cases, ``min_cost`` is treated as ``higher_is_worse``
+    In all travel-time cases, higher ``min_cost`` is treated as worse
     (lower travel time = better access), so the negation is applied
     automatically before any combination or Moran's I calculation.
 
@@ -593,7 +595,7 @@ class SiteSolutionHotspotCalculationMixin(SiteProblemHotspotCalculationMixin):
             equity_df = ctx.equity_data.copy()
             equity_col = ctx._equity_data_equity_col
 
-            if ctx._equity_data_direction == "higher_is_worse":
+            if ctx._equity_data_disadvantaged_end == "high":
                 equity_df["_equity_directed"] = -equity_df[equity_col]
             else:
                 equity_df["_equity_directed"] = equity_df[equity_col]

--- a/lokigi/mixins/site_solution_plots.py
+++ b/lokigi/mixins/site_solution_plots.py
@@ -1644,6 +1644,7 @@ class EquityPlotsMixin:
         rank_on=None,
         ax=None,
         colour_mode: Optional[Literal["gradient", "above_below_avg"]] = None,
+        show_site_names=False,
     ):
         """
         Summarise and optionally plot equity metrics for a selected solution.
@@ -1673,6 +1674,9 @@ class EquityPlotsMixin:
         ax : matplotlib.axes.Axes or None, optional
             Existing Matplotlib axes to plot on when ``interactive=False``.
             If None, a new figure and axes are created.
+        show_site_names : bool, default=False
+            If True, the default plot title lists the selected sites by name
+            (``site_names``) instead of by index (``site_indices``).
 
         Returns
         -------
@@ -1706,7 +1710,14 @@ class EquityPlotsMixin:
             return summary_equity_df
         else:
             if title == "default":
-                title = f"Solution equity - by {self.site_problem._equity_data_label}\nSolution Rank {solution_rank} (Site Indices {plotting_row.site_indices}) "
+                if show_site_names:
+                    sites_str = ", ".join(str(name) for name in plotting_row.site_names)
+                    sites_label = f"Sites: {sites_str}"
+                else:
+                    sites_str = ", ".join(str(int(i)) for i in plotting_row.site_indices)
+                    sites_label = f"Site Indices: {sites_str}"
+
+                title = f"Solution equity - by {self.site_problem._equity_data_label}\nSolution Rank {solution_rank} ({sites_label})"
 
             if show_average:
                 avg_value = plotting_row[plot_solution_metric_as_line]
@@ -1814,6 +1825,7 @@ class EquityPlotsMixin:
         colour_mode: Optional[Literal["gradient", "above_below_avg"]] = None,
         cols=2,
         figsize_multiplier=5,
+        show_site_names=False,
     ):
         """
         Plot equity summaries for the top N solutions in a grid of subplots.
@@ -1835,6 +1847,9 @@ class EquityPlotsMixin:
             dotted line on each subplot.
         cols : int, default=2
             Number of subplot columns. The number of rows is determined automatically.
+        show_site_names : bool, default=False
+            If True, each subplot title lists the selected sites by name
+            instead of by index.
 
         Returns
         -------
@@ -1869,6 +1884,7 @@ class EquityPlotsMixin:
                 plot_solution_metric_as_line=plot_solution_metric_as_line,
                 colour_mode=colour_mode,
                 ax=axes[i],
+                show_site_names=show_site_names,
             )
 
         # Remove unused axes if n doesn't fill grid

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -40,6 +40,21 @@ class BruteForceMixin:
         threshold_for_coverage=None,
     ):
 
+        # Greedy and GRASP already fail fast with a clear message when
+        # required sites can't fit in p; brute-force had no equivalent
+        # check and instead silently filtered every combination out in
+        # _generate_all_combinations below, falling through to the
+        # generic "No feasible solutions" guard in site.py -- whose
+        # wording ("checking that p does not exceed the number of
+        # candidate sites") is wrong for this case.
+        required_site_indices = _get_required_site_indices(self)
+        if len(required_site_indices) > p:
+            raise ValueError(
+                f"{len(required_site_indices)} sites are marked as required "
+                f"in '{self._candidate_sites_required_sites_col}', but p={p}. "
+                "Increase p to at least the number of required sites."
+            )
+
         keep_n_active = (
             brute_force_keep_best_n is not None or brute_force_keep_worst_n is not None
         )

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -251,10 +251,20 @@ class GreedyMixin:
                     weights=weights,
                     higher_is_better=higher_is_better,
                 )
-                sort_ascending = [True, True]
             else:
                 score_col = ranking
-                sort_ascending = [not higher_is_better, True]
+
+            # _apply_cost_weighting only blends onto its lower-is-better
+            # "composite_score" scale when it actually has usable cost data
+            # to blend (a positive cost weight is not enough on its own --
+            # it also no-ops, returning score_col == ranking unchanged, when
+            # e.g. every candidate's total_cost is NaN). Assuming "cost
+            # weight requested" implies "blended, therefore ascending" was
+            # wrong: for a higher-is-better objective (mclp) whose cost
+            # weighting silently no-ops, sorting ascending on the raw
+            # ranking column picks the WORST combination as "best".
+            blended = score_col != ranking
+            sort_ascending = [True, True] if blended else [not higher_is_better, True]
 
             evaluated_solutions = outputs_df.sort_values(
                 [score_col, "weighted_average"], ascending=sort_ascending
@@ -429,7 +439,19 @@ class GraspMixin:
                         weights=weights,
                         higher_is_better=not is_minimization,
                     )
-                    scores_minimized = True
+                    # _apply_cost_weighting only blends onto its
+                    # lower-is-better "composite_score" scale when it has
+                    # usable cost data to blend -- a positive cost weight
+                    # alone isn't enough, it also no-ops (score_col ==
+                    # ranking unchanged) when e.g. every candidate's
+                    # total_cost is NaN. Assuming "cost requested" implies
+                    # "blended, therefore minimised" was wrong: for a
+                    # maximising objective (mclp) whose cost weighting
+                    # silently no-ops, treating its raw score as
+                    # lower-is-better picks the WORST candidates for the RCL.
+                    scores_minimized = (
+                        True if score_col != ranking else is_minimization
+                    )
                     candidate_scores: list[tuple[float, float, int]] = list(
                         zip(
                             candidates_df[score_col],
@@ -583,28 +605,27 @@ class GraspMixin:
                             # _apply_cost_weighting: it inverts the raw
                             # ranking column into "badness" (0=best) before
                             # blending in cost, and the returned score_col
-                            # ("composite_score") is unconditionally on that
-                            # same lower-is-better, 0-is-best scale --
-                            # regardless of whether the underlying objective
-                            # is minimized (e.g. weighted_average) or
-                            # maximized (e.g. mclp's coverage proportion).
-                            #
-                            # That's why the comparison below is a plain "<"
-                            # with no is_minimization/higher_is_better branch,
-                            # unlike the raw-metric comparison in the
-                            # non-cost branch above. Do NOT wrap it in an
-                            # `if is_minimization: ... else: ...` to mirror
-                            # that branch -- the direction has already been
-                            # normalized once by _apply_cost_weighting, and
-                            # inverting it a second time here would make this
-                            # code pick the worst swap instead of the best
-                            # one for every maximizing objective (mclp).
+                            # ("composite_score") is on that same
+                            # lower-is-better, 0-is-best scale regardless of
+                            # whether the underlying objective is minimized
+                            # (e.g. weighted_average) or maximized (e.g.
+                            # mclp's coverage proportion) -- BUT ONLY when
+                            # it actually blends. _apply_cost_weighting also
+                            # no-ops (returns score_col == ranking_col
+                            # unchanged) when it lacks usable cost data to
+                            # blend (e.g. every candidate's total_cost is
+                            # NaN), in which case score_col is back on the
+                            # ORIGINAL objective's natural scale, and a
+                            # blind "<" would pick the worst swap instead of
+                            # the best one for a maximizing objective (mclp)
+                            # whose cost weighting silently no-op'd.
                             batch_df, score_col = _apply_cost_weighting(
                                 pd.DataFrame(rows),
                                 ranking_col=ranking,
                                 weights=weights,
                                 higher_is_better=not is_minimization,
                             )
+                            blended = score_col != ranking
                             current_score = batch_df.iloc[0][score_col]
                             current_secondary_score = batch_df.iloc[0][
                                 "weighted_average"
@@ -623,10 +644,17 @@ class GraspMixin:
                             for i, row in batch_df.iloc[1:].reset_index(
                                 drop=True
                             ).iterrows():
-                                if (row[score_col], row["weighted_average"]) < (
-                                    current_score,
-                                    current_secondary_score,
-                                ):
+                                candidate_score = (
+                                    row[score_col],
+                                    row["weighted_average"],
+                                )
+                                current = (current_score, current_secondary_score)
+                                is_better = (
+                                    candidate_score < current
+                                    if (blended or is_minimization)
+                                    else candidate_score > current
+                                )
+                                if is_better:
                                     current_solution = swap_candidates[i]
                                     current_solution_set = set(current_solution)
                                     improved = True

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -333,7 +333,22 @@ class GraspMixin:
                 "Increase p to at least the number of required sites."
             )
 
-        min_jaccard_distance = float(min_sites_different) / float(p)
+        # min_sites_different (m) means "any two accepted solutions must
+        # differ in at least m of their p site positions", i.e. their
+        # intersection size k must satisfy p - k >= m, i.e. k <= p - m.
+        # For two same-size (p) sets with intersection k, Jaccard distance
+        # is 2(p-k) / (2p-k) -- NOT the plain fraction m/p this used to use.
+        # Solving for the distance at the exact boundary k = p - m (the
+        # most-similar pair that should still be ACCEPTED) gives
+        # 2m / (p + m), which is strictly larger than m/p whenever m > 1
+        # and p > m. The old, smaller m/p threshold rejected fewer
+        # candidates than intended: for m >= 3 (and p large enough
+        # relative to m, e.g. p >= 6 at m=3), pairs differing in only m-1
+        # sites -- one site too similar -- were wrongly accepted as
+        # "diverse enough".
+        min_jaccard_distance = (2.0 * float(min_sites_different)) / (
+            float(p) + float(min_sites_different)
+        )
 
         # Only the non-required slots are free to vary, so that's the true
         # size of the search space the attempt budget is drawn from.

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -40,10 +40,48 @@ class BruteForceMixin:
         threshold_for_coverage=None,
     ):
 
-        if brute_force_keep_best_n is not None:
+        keep_n_active = (
+            brute_force_keep_best_n is not None or brute_force_keep_worst_n is not None
+        )
+
+        # _apply_cost_weighting does batch-relative min-max normalization: it
+        # needs to see every combination's ranking value and total_cost at
+        # once to normalise either meaningfully. That's incompatible with
+        # keep_best_n/keep_worst_n's streaming heap below, which prunes to N
+        # using the raw, pre-cost ranking value one combination at a time --
+        # a combination with a mediocre raw ranking but a low cost could be
+        # the true cost-weighted best, yet never survive the heap because
+        # cost is never considered until after _brute_force returns. So
+        # whenever cost weighting is actually requested, keep_best_n/
+        # keep_worst_n fall back to materialising every combination (the
+        # same way the "keep everything" path already does) and only prune
+        # AFTER cost has been blended in over the full batch. This trades
+        # away keep_best_n/keep_worst_n's memory-saving benefit for
+        # correctness whenever cost weighting is active; BRUTE_FORCE_WARN_
+        # THRESHOLD/BRUTE_FORCE_LIMIT above still guard against unbounded
+        # memory use either way.
+        use_cost_weighting = bool(weights) and weights.get("cost", 0) > 0
+        stream_top_n = keep_n_active and not use_cost_weighting
+
+        if keep_n_active and use_cost_weighting:
+            warn(
+                "brute_force_keep_best_n/brute_force_keep_worst_n was "
+                "requested together with a cost weight (weights['cost']). "
+                "Pruning to the top/bottom N using the raw ranking value, "
+                "before cost is blended in, could discard the true cost-"
+                "weighted best/worst combination. To stay correct, every "
+                "combination is being evaluated and held in memory so cost "
+                "weighting can be applied over the full set before pruning "
+                "-- this forgoes keep_best_n/keep_worst_n's usual memory-"
+                "saving benefit for this run.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        if stream_top_n and brute_force_keep_best_n is not None:
             top_n_heap = []  # To store the smallest scores (best)
             # print(f"Keeping top {brute_force_keep_best_n}")
-        if brute_force_keep_worst_n is not None:
+        if stream_top_n and brute_force_keep_worst_n is not None:
             bottom_n_heap = []  # To store the largest scores (worst)
             # print(f"Keeping worst {brute_force_keep_worst_n}")
 
@@ -81,8 +119,11 @@ class BruteForceMixin:
             possible_combinations = tqdm(possible_combinations)
 
         for possible_solution in possible_combinations:
-            if brute_force_keep_best_n is None and brute_force_keep_worst_n is None:
-                # Keep all results
+            if not stream_top_n:
+                # Keep all results -- either because no pruning was
+                # requested, or because cost weighting is active and every
+                # combination must be materialised before pruning (see
+                # `use_cost_weighting` above).
                 single_solution_metrics = (
                     self.evaluate_single_solution_single_objective(
                         site_indices=possible_solution,
@@ -139,8 +180,50 @@ class BruteForceMixin:
                                 bottom_n_heap, (score, next(tie_breaker), metrics)
                             )
 
-        if brute_force_keep_best_n is None and brute_force_keep_worst_n is None:
+        if not keep_n_active:
             return outputs
+
+        if use_cost_weighting:
+            # `outputs` was fully materialised above (the `not stream_top_n`
+            # branch), so cost weighting can be applied once, correctly,
+            # over the whole batch, and only then pruned to N.
+            if not outputs:
+                return []
+
+            outputs_df = pd.DataFrame(outputs)
+            outputs_df, score_col = _apply_cost_weighting(
+                outputs_df,
+                ranking_col=rank_best_n_on,
+                weights=weights,
+                higher_is_better=higher_is_better,
+            )
+
+            # _apply_cost_weighting's blended "composite_score" is always on
+            # a lower-is-better scale regardless of the underlying
+            # objective's direction -- but only when it actually blends. It
+            # no-ops (score_col == rank_best_n_on unchanged) when it lacks
+            # usable cost data, in which case the raw ranking column keeps
+            # its own direction (higher-is-better for mclp).
+            best_is_smallest = not (score_col == rank_best_n_on and higher_is_better)
+
+            result_frames = []
+            if brute_force_keep_best_n is not None:
+                result_frames.append(
+                    outputs_df.nsmallest(brute_force_keep_best_n, score_col)
+                    if best_is_smallest
+                    else outputs_df.nlargest(brute_force_keep_best_n, score_col)
+                )
+            if brute_force_keep_worst_n is not None:
+                result_frames.append(
+                    outputs_df.nlargest(brute_force_keep_worst_n, score_col)
+                    if best_is_smallest
+                    else outputs_df.nsmallest(brute_force_keep_worst_n, score_col)
+                )
+
+            combined = (
+                pd.concat(result_frames) if len(result_frames) > 1 else result_frames[0]
+            )
+            return combined.to_dict("records")
         else:
             # Reconstruct the 'outputs' list
             # Extract dictionaries from heaps and sort them

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -174,10 +174,24 @@ class GreedyMixin:
     ):
         ranking = _get_ranking_by_objective(objective=objectives)
 
-        # Loop through
-        best_indices = []
+        # Greedy grows the solution one site at a time, but every size-i
+        # combination is also filtered to contain ALL required sites -- so
+        # with two or more required sites, the early steps (i < n_required)
+        # had no valid combinations at all and crashed on the empty result.
+        # Seed the build with the required sites instead, and start the
+        # loop at that size (its first step then just evaluates the
+        # required set itself before free choices begin).
+        required_site_indices = _get_required_site_indices(self)
+        if len(required_site_indices) > p:
+            raise ValueError(
+                f"{len(required_site_indices)} sites are marked as required "
+                f"in '{self._candidate_sites_required_sites_col}', but p={p}. "
+                "Increase p to at least the number of required sites."
+            )
 
-        loop_iterations = range(1, p + 1)
+        best_indices = list(required_site_indices)
+
+        loop_iterations = range(max(1, len(required_site_indices)), p + 1)
         if show_progress:
             loop_iterations = tqdm(loop_iterations)
 
@@ -187,7 +201,7 @@ class GreedyMixin:
                 n_facilities=self.total_n_sites,
                 p=i,
                 site_problem=self,
-                force_include_indices=None if i == 1 else list(best_indices),
+                force_include_indices=list(best_indices) if best_indices else None,
             )
 
             # print(f"Possible combinations: {possible_combinations}")

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -157,6 +157,7 @@ class GreedyMixin:
         weights,
         show_progress: bool = False,
         threshold_for_coverage=None,
+        max_value_cutoff=None,
     ):
         ranking = _get_ranking_by_objective(objective=objectives)
 
@@ -195,6 +196,26 @@ class GreedyMixin:
             # while every other objective's ranking column is lower-is-better
             outputs_df = pd.DataFrame(outputs)
             higher_is_better = objectives == "mclp"
+
+            # The max-value cutoff (hybrid objectives) is a constraint on
+            # the FINAL solution only: with fewer than p sites the
+            # worst-case travel is usually still shrinking, so filtering
+            # intermediate steps would wrongly rule everything out. At the
+            # final step, keep only combinations meeting the cutoff so the
+            # guarantee the hybrid objectives promise actually holds for
+            # whatever is returned.
+            if max_value_cutoff is not None and i == p:
+                outputs_df = outputs_df[outputs_df["max"] <= max_value_cutoff]
+                if len(outputs_df) == 0:
+                    raise ValueError(
+                        f"Greedy search found no combination of {p} sites "
+                        f"meeting max_value_cutoff={max_value_cutoff}, given "
+                        "the sites fixed at earlier steps "
+                        f"({sorted(int(s) for s in best_indices)}). Greedy "
+                        "never revisits earlier choices, so a feasible "
+                        "solution may still exist -- try search_strategy="
+                        "'brute-force' or 'grasp', or relax the cutoff."
+                    )
 
             if weights and weights.get("cost", 0) > 0:
                 outputs_df, score_col = _apply_cost_weighting(
@@ -261,6 +282,7 @@ class GraspMixin:
         is_minimization: bool = True,  # Flag for sort order & thresholding
         local_search_chance=0.8,  # Chance that local searching will happen to improve found solution
         max_swap_count_local_search=10,
+        max_value_cutoff=None,
     ):
         """
         GRASP (Greedy Randomised Adaptive Search Procedure) for finding multiple
@@ -544,6 +566,20 @@ class GraspMixin:
                                     current_solution_set = set(current_solution)
                                     improved = True
                                     break
+
+            # ---------------------------------------------------------------
+            # FEASIBILITY CHECK (hybrid objectives' max-value cutoff)
+            # ---------------------------------------------------------------
+            # Judged on the finished (post-local-search) solution: with
+            # fewer than p sites mid-construction, the worst-case travel is
+            # usually still shrinking, so only the final form is checked.
+            # A rejected solution costs an attempt, like a diversity reject.
+            if max_value_cutoff is not None:
+                candidate_metrics = _get_cached_metrics(
+                    tuple(sorted(current_solution))
+                )
+                if candidate_metrics["max"] > max_value_cutoff:
+                    continue
 
             # ---------------------------------------------------------------
             # DIVERSITY CHECK

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -1,6 +1,7 @@
 from lokigi.utils import (
     _generate_all_combinations,
     _get_ranking_by_objective,
+    _get_required_site_indices,
     _too_similar_to_accepted,
     _apply_cost_weighting,
 )
@@ -304,9 +305,28 @@ class GraspMixin:
         ranking = _get_ranking_by_objective(objective=objectives)
         all_site_indices = list(range(self.total_n_sites))
 
+        # Brute force and greedy enforce required_sites_col through
+        # _generate_all_combinations, but GRASP builds solutions
+        # incrementally and never calls it -- so required sites must be
+        # pinned here: seeded into every construction, and protected from
+        # being swapped out during local search.
+        required_site_indices = _get_required_site_indices(self)
+        required_site_set = set(required_site_indices)
+        if len(required_site_indices) > p:
+            raise ValueError(
+                f"{len(required_site_indices)} sites are marked as required "
+                f"in '{self._candidate_sites_required_sites_col}', but p={p}. "
+                "Increase p to at least the number of required sites."
+            )
+
         min_jaccard_distance = float(min_sites_different) / float(p)
 
-        total_combinations = math.comb(self.total_n_sites, p)
+        # Only the non-required slots are free to vary, so that's the true
+        # size of the search space the attempt budget is drawn from.
+        total_combinations = math.comb(
+            self.total_n_sites - len(required_site_indices),
+            p - len(required_site_indices),
+        )
         if max_attempts == "default":
             max_attempts = min(num_solutions * 20, total_combinations)
 
@@ -343,11 +363,11 @@ class GraspMixin:
             # ---------------------------------------------------------------
             # CONSTRUCTION PHASE
             # ---------------------------------------------------------------
-            current_solution: list[int] = []
-            current_solution_set: set[int] = set()
+            current_solution: list[int] = list(required_site_indices)
+            current_solution_set: set[int] = set(current_solution)
             construction_failed = False
 
-            for step in range(p):
+            for step in range(p - len(required_site_indices)):
                 remaining_sites = [
                     s for s in all_site_indices if s not in current_solution_set
                 ]
@@ -458,6 +478,8 @@ class GraspMixin:
                         # Lazy pairwise first-improvement scan (unchanged from
                         # before cost weighting was introduced).
                         for old_site in current_solution:
+                            if old_site in required_site_set:
+                                continue
                             for new_site in outside_sites:
                                 candidate = [
                                     s for s in current_solution if s != old_site
@@ -507,6 +529,8 @@ class GraspMixin:
                         ]
                         swap_candidates = []
                         for old_site in current_solution:
+                            if old_site in required_site_set:
+                                continue
                             for new_site in outside_sites:
                                 candidate = [
                                     s for s in current_solution if s != old_site

--- a/lokigi/mixins/site_solvers.py
+++ b/lokigi/mixins/site_solvers.py
@@ -72,6 +72,10 @@ class BruteForceMixin:
 
         outputs = []
 
+        # mclp's ranking column (coverage proportion) is higher-is-better,
+        # while every other objective's ranking column is lower-is-better.
+        higher_is_better = objectives == "mclp"
+
         if show_progress:
             possible_combinations = tqdm(possible_combinations)
 
@@ -99,10 +103,18 @@ class BruteForceMixin:
                 metrics = self.evaluate_single_solution_single_objective(
                     site_indices=possible_solution,
                     objective=objectives,
+                    threshold_for_coverage=threshold_for_coverage,
                     weights=weights,
                 ).return_solution_metrics()
 
-                score = metrics[rank_best_n_on]
+                raw_score = metrics[rank_best_n_on]
+                # Normalise so lower always means better: the heaps below
+                # keep the N smallest scores as "best" and the N largest as
+                # "worst", which only holds for minimising objectives.
+                # Negating mclp's coverage proportion lets the same heap
+                # logic serve both directions -- without this, keep_best_n
+                # for mclp retained the WORST-coverage combinations.
+                score = -raw_score if higher_is_better else raw_score
                 max_value = metrics["max"]
 
                 if max_value_cutoff is None or (

--- a/lokigi/problem.py
+++ b/lokigi/problem.py
@@ -87,7 +87,7 @@ class _Problem:
         equity_col,
         common_col,
         label,
-        direction: Literal["higher_is_better", "higher_is_worse"] = "higher_is_worse",
+        direction: Literal["higher_is_better", "higher_is_worse"] = "higher_is_better",
         continuous_measure: bool = False,
         n_bins: int = 10,
         reverse: bool = False,

--- a/lokigi/problem.py
+++ b/lokigi/problem.py
@@ -38,7 +38,7 @@ class _Problem:
         self._equity_data_equity_col = None
         self._equity_data_common_col = None
         self._equity_data_label = None
-        self._equity_data_direction = None
+        self._equity_data_disadvantaged_end = None
 
         self.geo_lookup = None
         self._geo_lookup_data_type = None
@@ -87,11 +87,12 @@ class _Problem:
         equity_col,
         common_col,
         label,
-        direction: Literal["higher_is_better", "higher_is_worse"] = "higher_is_better",
+        disadvantaged_end: Literal["low", "high"] | None = None,
         continuous_measure: bool = False,
         n_bins: int = 10,
         reverse: bool = False,
         verbose: bool = True,
+        direction: Literal["higher_is_better", "higher_is_worse"] | None = None,
     ):
         """
         Add a dataframe containing equity data into your problem.
@@ -116,23 +117,25 @@ class _Problem:
             A human-readable label for the equity metric (e.g., 'IMD Decile',
             'Age Group'). This is used internally for auto-generating plot
             titles and table headers.
-        direction : {"higher_is_better", "higher_is_worse"}, default "higher_is_better"
-            Indicates whether higher values of `equity_col` represent a more or
-            less advantaged group. This is stored as metadata and applied at
-            analysis time — it does not modify the stored data.
+        disadvantaged_end : {"low", "high"}, default "low"
+            Which end of the `equity_col` scale represents the most
+            disadvantaged (e.g. most deprived) regions. This is stored as
+            metadata and applied at analysis time — it does not modify the
+            stored data. Equity-aware weighting and analysis prioritise
+            whichever end you name here.
 
-            - ``"higher_is_better"`` : higher values indicate a more favourable
-            equity position (e.g. IMD decile 10 = least deprived under the
-            standard DLUHC 1–10 scale).
-            - ``"higher_is_worse"`` : higher values indicate greater disadvantage
+            - ``"low"`` : the lowest values are the most disadvantaged
+            (e.g. IMD decile 1 = most deprived under the standard DLUHC
+            1–10 scale).
+            - ``"high"`` : the highest values are the most disadvantaged
             (e.g. raw IMD score, where a higher score means more deprived;
             or a custom scale where 1 = least deprived).
 
             .. note::
                 IMD *deciles* as published by DLUHC run 1 (most deprived) to 10
                 (least deprived), so for pre-binned IMD decile columns use
-                ``direction="higher_is_better"``. For raw IMD *scores* (higher =
-                more deprived) use ``direction="higher_is_worse"``.
+                ``disadvantaged_end="low"``. For raw IMD *scores* (higher =
+                more deprived) use ``disadvantaged_end="high"``.
         continuous_measure : bool, default False
             If True, treats `equity_col` as continuous numerical data and
             uses quantile-based discretization to convert it into deciles (1-10).
@@ -152,6 +155,14 @@ class _Problem:
             governs downstream analysis rather than how bins are labelled.
         verbose: bool, default True
             If True, output additional warnings and messages
+        direction : {"higher_is_better", "higher_is_worse"}, optional
+            .. deprecated::
+                Use ``disadvantaged_end`` instead. ``"higher_is_better"``
+                (higher values = more advantaged, e.g. DLUHC IMD deciles)
+                maps to ``disadvantaged_end="low"``; ``"higher_is_worse"``
+                (higher values = more disadvantaged, e.g. raw IMD scores)
+                maps to ``disadvantaged_end="high"``. Passing both arguments
+                raises a ``ValueError``.
 
         Raises
         ------
@@ -166,6 +177,38 @@ class _Problem:
         this may result in fewer than 10 bins. The method handles this dynamically
         to ensure the resulting categories always start at 1.
         """
+        if direction is not None:
+            if disadvantaged_end is not None:
+                raise ValueError(
+                    "Please provide only 'disadvantaged_end' -- 'direction' is "
+                    "its deprecated alias, and passing both is ambiguous."
+                )
+            if direction not in ("higher_is_better", "higher_is_worse"):
+                raise ValueError(
+                    "direction must be one of 'higher_is_better' or "
+                    f"'higher_is_worse'. You provided '{direction}'."
+                )
+            warn(
+                "The 'direction' argument to add_equity_data() is deprecated. "
+                "Use disadvantaged_end='low' instead of "
+                "direction='higher_is_better' (lowest values = most deprived, "
+                "e.g. DLUHC IMD deciles), and disadvantaged_end='high' instead "
+                "of direction='higher_is_worse' (highest values = most "
+                "deprived, e.g. raw IMD scores).",
+                FutureWarning,
+                stacklevel=2,
+            )
+            disadvantaged_end = "low" if direction == "higher_is_better" else "high"
+        elif disadvantaged_end is None:
+            # DLUHC IMD deciles (1 = most deprived) are the most common input.
+            disadvantaged_end = "low"
+
+        if disadvantaged_end not in ("low", "high"):
+            raise ValueError(
+                "disadvantaged_end must be one of 'low' or 'high'. "
+                f"You provided '{disadvantaged_end}'."
+            )
+
         loaded_df, df_type = _load_spatial_or_tabular_data(equity_data)
 
         if verbose:
@@ -217,7 +260,7 @@ class _Problem:
         self._equity_data_equity_col = equity_col
         self._equity_data_common_col = common_col
         self._equity_data_label = label
-        self._equity_data_direction = direction
+        self._equity_data_disadvantaged_end = disadvantaged_end
 
     def show_equity_data(self):
         return self.equity_data

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -195,13 +195,28 @@ class SiteProblem(
         if objective not in SUPPORTED_OBJECTIVES:
             raise ValueError(f"Unsupported objective ({objective}) passed.")
 
-        # Ensure exactly one argument is provided out of site_names and site_indices
+        # Ensure exactly one argument is provided out of site_names and
+        # site_indices. Checked via `is not None` rather than truthiness --
+        # `site_names and site_indices` treated an explicitly-passed empty
+        # list ([]) as "not provided", so e.g. site_names=[] alongside
+        # site_indices=[1] silently skipped the "not both" check.
         if (site_names is None and site_indices is None) or (
-            site_names and site_indices
+            site_names is not None and site_indices is not None
         ):
             raise ValueError(
                 "Please provide either 'site_names' or 'site_indices', but not both. "
                 "This helps prevent 'off-by-one' errors with numeric site IDs."
+            )
+
+        if (site_names is not None and len(site_names) == 0) or (
+            site_indices is not None and len(site_indices) == 0
+        ):
+            raise ValueError("'site_names'/'site_indices' must not be an empty list.")
+
+        if site_indices is not None and len(site_indices) != len(set(site_indices)):
+            raise ValueError(
+                f"site_indices contains duplicate entries: {site_indices}. "
+                "Each site may only be selected once per solution."
             )
 
         try:
@@ -214,16 +229,25 @@ class SiteProblem(
             # We need to make sure that we use IDs and names completely consistently throughout.
             # 1. Resolve site_indices to actual Site IDs (names)
             if site_indices is not None:
+                # .isin() silently drops any index that doesn't exist,
+                # which is why "is the result non-empty" alone (the old
+                # check here) wasn't enough: a partially-invalid list still
+                # produced a non-empty result, silently evaluating a
+                # smaller solution than the caller asked for. Check for
+                # exactly which requested indices don't exist.
+                valid_indices = set(self.candidate_sites["canonical_site_index"])
+                invalid_indices = sorted(set(site_indices) - valid_indices)
+                if invalid_indices:
+                    raise IndexError(
+                        f"Site indices {invalid_indices} not found in candidate "
+                        f"sites (valid range: 0 to {self.total_n_sites - 1})."
+                    )
+
                 # Use .iloc to get the actual ID/Name from the master site list
                 resolved_names = self.candidate_sites[
                     self.candidate_sites["canonical_site_index"].isin(site_indices)
                 ][self._candidate_sites_candidate_id_col].tolist()
                 # print(f"Site indices provided. Resolved names: {resolved_names}")
-
-                if not resolved_names:
-                    raise IndexError(
-                        f"Indices {site_indices} not found in candidate sites."
-                    )
             else:
                 # print(f"Name provided. Resolved names: {site_names}")
                 resolved_names = site_names

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -967,10 +967,21 @@ class SiteProblem(
                 weights=weights,
                 higher_is_better=higher_is_better,
             )
-            score_ascending = True
         else:
             score_col = ranking
-            score_ascending = not higher_is_better
+
+        # _apply_cost_weighting only blends onto its lower-is-better
+        # "composite_score" scale when it actually has usable cost data to
+        # blend; it no-ops (returns score_col == ranking unchanged) when
+        # e.g. every candidate's total_cost is NaN. Assuming "cost weight
+        # requested" implies "blended, therefore ascending" was wrong: for
+        # mclp (higher-is-better coverage proportion) whose cost weighting
+        # silently no-ops, sorting ascending on the raw ranking column
+        # ranks the WORST combination first. This is the final cross-
+        # strategy sort applied after brute-force/greedy/grasp all
+        # return, so it affects every search strategy alike.
+        blended = score_col != ranking
+        score_ascending = True if blended else not higher_is_better
 
         solution_df = _add_rank_column(
             outputs_df,

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -372,11 +372,19 @@ class SiteProblem(
                 # print(f"active_facilities: {active_facilities.head(1)}")
                 # print(f"self.equity_data: {self.equity_data.head(1)}")
 
+                # how="left": demand points missing from the equity data
+                # must keep their travel/cost rows (with NaN equity values)
+                # rather than being dropped from the evaluation. An inner
+                # join here silently shrank every metric -- max, weighted
+                # averages, coverage -- whenever the equity data didn't
+                # cover all demand locations, even when equity wasn't
+                # being weighted.
                 active_facilities = pd.merge(
                     active_facilities,
                     self.equity_data,
                     left_on=afi,
                     right_on=self._equity_data_common_col,
+                    how="left",
                     suffixes=("", "_y"),
                 )
 
@@ -641,6 +649,37 @@ class SiteProblem(
             raise KeyError(
                 f"The following weight keys are missing from the problem data: {missing_cols}"
             )
+
+        # Equity coverage check. The per-solution equity merge is a left
+        # join, so demand locations missing from the equity data keep their
+        # travel metrics but carry NaN equity values. That is fatal for
+        # equity weighting (the row weights would be NaN) and silently
+        # excludes those locations from equity-band breakdowns, so surface
+        # it here, once, before any solving starts.
+        if self.equity_data is not None:
+            demand_ids = self.travel_and_demand_df.index
+            equity_ids = self.equity_data[self._equity_data_common_col]
+            missing_equity_ids = demand_ids.difference(equity_ids)
+
+            if len(missing_equity_ids) > 0:
+                id_summary = (
+                    f"{len(missing_equity_ids)} of {len(demand_ids)} demand "
+                    f"location(s) have no matching row in the equity data "
+                    f"(e.g. {list(missing_equity_ids[:5])})"
+                )
+                if any(key.lower() == "equity" for key in weights):
+                    raise ValueError(
+                        f"Cannot weight by equity: {id_summary}. Equity row "
+                        "weights cannot be computed for these locations. "
+                        "Please provide equity data covering every demand "
+                        "location, or remove 'equity' from the weights dict."
+                    )
+                warn(
+                    f"{id_summary}. These locations are still included in "
+                    "all travel/cost metrics, but will be excluded from "
+                    "equity-band breakdowns (e.g. coverage or averages per "
+                    "equity group)."
+                )
 
         if isinstance(objectives, list) and len(objectives) > 1:
             warn(

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -614,7 +614,12 @@ class SiteProblem(
         # If demand data not present,a ssume equal demand
         if self.demand_data is None:
             self._setup_equal_demand_df()
-            if objectives != "mclp":
+            # Compare against `objective` (the already-resolved single
+            # string), not the raw `objectives` parameter -- when the
+            # caller passes a list (e.g. objectives=["mclp"]), a list is
+            # never equal to the string "mclp", so this warning fired even
+            # for the exempted mclp objective.
+            if objective != "mclp":
                 warn(
                     "No demand data was provided. Demand from all regions has been assumed to be equal."
                     "If you wish to override this, run .add_demand() to add your site dataframe before running .solve() again."

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -581,14 +581,24 @@ class SiteProblem(
         # Normalise weights to ensure they sum to exactly 1.0
         # This safely handles {"demand": 80, "equity": 20} -> {"demand": 0.8, "equity": 0.2}
         #
-        # The "cost" key is canonicalised to lowercase here because every
-        # downstream consumer (site_solvers.py, utils._apply_cost_weighting)
-        # looks it up via an exact-case weights.get("cost", ...), even though
-        # the validation above accepts it case-insensitively -- without this,
-        # a differently-cased key like "Cost" would pass validation but
-        # silently never influence the solution.
+        # "demand", "equity", and "cost" are canonicalised to lowercase here
+        # because every downstream consumer (site_solutions.py,
+        # site_solvers.py, utils._apply_cost_weighting) looks them up via
+        # exact-case comparisons/lookups, even though the missing-key
+        # validation below accepts all three case-insensitively -- without
+        # this, a differently-cased key like "Demand" or "Equity" would pass
+        # validation but then silently fail to match any known column,
+        # leaving the compound row weights all zero and crashing
+        # np.average with "Weights sum to zero". Additional-data labels are
+        # user-defined exact strings (not built-in keywords) and are
+        # deliberately left untouched -- they are matched case-sensitively
+        # on both sides (here and in site_solutions.py).
+        _canonical_weight_keys = {"demand", "equity", "cost"}
         normalised_weights = {
-            ("cost" if col.lower() == "cost" else col): float(weight) / total_weight
+            (col.lower() if col.lower() in _canonical_weight_keys else col): float(
+                weight
+            )
+            / total_weight
             for col, weight in weights.items()
         }
 

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -469,7 +469,11 @@ class SiteProblem(
             brute-force search.
         max_value_cutoff : float, optional
             The maximum allowable travel cost. Only applicable for hybrid
-            objective models.
+            objective models. All search strategies honour it: brute-force
+            discards every combination whose worst-case travel exceeds it,
+            greedy applies it when choosing the final site (raising a
+            ValueError if no feasible completion exists), and GRASP rejects
+            candidate solutions that violate it.
         threshold_for_coverage : float, optional
             The distance or time threshold. Used as a hard filter for MCLP
             objectives or as a scoring metric for others.
@@ -692,15 +696,6 @@ class SiteProblem(
             "hybrid_simple_p_median",
         ]:
             raise ValueError(
-                f"A max value cutoff of {max_value_cutoff} has been provided for a model objective ({objective} that doesn't support it.)"
-                "Please rerun with hybrid_p_median or hybrid_simple_p_median."
-            )
-
-        if max_value_cutoff is not None and objective not in [
-            "hybrid_p_median",
-            "hybrid_simple_p_median",
-        ]:
-            raise ValueError(
                 f"A max value cutoff of {max_value_cutoff} has been provided for a model variant ({objective}) that doesn't support it."
                 "Please rerun with hybrid_p_median or hybrid_simple_p_median."
             )
@@ -881,6 +876,7 @@ class SiteProblem(
                 objectives=objective,
                 show_progress=show_progress,
                 threshold_for_coverage=threshold_for_coverage,
+                max_value_cutoff=max_value_cutoff,
             )
 
         if search_strategy == "grasp":
@@ -900,6 +896,25 @@ class SiteProblem(
                 is_minimization=objective != "mclp",
                 local_search_chance=grasp_local_search_chance,  # Chance that local searching will happen to improve found solution
                 max_swap_count_local_search=grasp_max_swap_count_local_search,
+                max_value_cutoff=max_value_cutoff,
+            )
+
+        # An empty result set would otherwise crash further down with a
+        # cryptic KeyError when ranking columns are missing from the empty
+        # DataFrame -- most commonly caused by a max_value_cutoff strict
+        # enough to rule out every combination.
+        if len(outputs) == 0:
+            cutoff_note = (
+                f" with max_value_cutoff={max_value_cutoff}"
+                if max_value_cutoff is not None
+                else ""
+            )
+            raise ValueError(
+                f"No feasible solutions were found for objective '{objective}' "
+                f"using search_strategy='{search_strategy}'{cutoff_note}. "
+                "Try relaxing max_value_cutoff, checking that p does not "
+                "exceed the number of candidate sites, or using a different "
+                "search strategy."
             )
 
         higher_is_better = objective == "mclp"

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -493,7 +493,14 @@ class SiteProblem(
             If True, displays a progress bar during the optimization process.
         brute_force_keep_best_n / brute_force_keep_worst_n : int, optional
             (Brute Force only) The number of top or bottom results to retain during a
-            brute-force search.
+            brute-force search. Normally this prunes combinations on the fly
+            to bound memory use. If `weights` includes a positive "cost"
+            weight, that streaming prune is skipped: every combination is
+            evaluated and held in memory so cost can be blended in over the
+            full batch before pruning to N, otherwise a combination that
+            only looks good once cost is considered could be discarded
+            before cost is ever factored in. A UserWarning is raised when
+            this fallback is triggered.
         max_value_cutoff : float, optional
             The maximum allowable travel cost. Only applicable for hybrid
             objective models. All search strategies honour it: brute-force
@@ -833,10 +840,15 @@ class SiteProblem(
             combinations for exhaustive searches.
         brute_force_keep_best_n : int, optional
             (Brute Force) The number of top-performing combinations to retain in
-            brute-force results.
+            brute-force results. If `weights` includes a positive "cost"
+            weight, pruning falls back to materialising every combination
+            first so cost can be blended in over the full batch before
+            pruning to N (see `_brute_force`); a UserWarning is raised when
+            this happens.
         brute_force_keep_worst_n : int, optional
             (Brute Force) The number of lowest-performing combinations to retain in
-            brute-force results.
+            brute-force results. Same cost-weighting fallback as
+            `brute_force_keep_best_n` applies.
         max_value_cutoff : float, optional
             The maximum allowable travel cost, used only for hybrid
             objective models.

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -427,7 +427,6 @@ class SiteProblem(
         grasp_local_search_chance=0.8,  # Chance that local searching will happen to improve found solution
         grasp_max_swap_count_local_search=10,
         random_seed=42,
-        **kwargs,
     ):
         """
         Solve the site location problem using the specified objective and strategy.
@@ -497,8 +496,6 @@ class SiteProblem(
             local search phase.
         random_seed : int, default 42
             (GRASP only) Seed for reproducibility in randomized strategies like GRASP.
-        **kwargs : dict
-            Additional arguments passed to the internal solver.
 
         Returns
         -------

--- a/lokigi/site.py
+++ b/lokigi/site.py
@@ -335,10 +335,14 @@ class SiteProblem(
             ].copy()
 
         except IndexError:
+            # Copy-paste bug: this used to report `max_idx` twice (once as
+            # the valid upper bound, then again mislabelled as "You
+            # provided indices"), instead of the column positions that
+            # were actually attempted.
             max_idx = self.travel_and_demand_df.shape[1] - 1
             raise IndexError(
                 f"Index out of bounds. Your travel data has indices 0 to {max_idx}. "
-                f"You provided indices: {max_idx}"
+                f"You provided indices: {final_matrix_cols}"
             )
 
         if not capacitated:

--- a/lokigi/site_solutions.py
+++ b/lokigi/site_solutions.py
@@ -203,6 +203,22 @@ class EvaluatedCombination:
                     # Extract raw data
                     column_data = self.evaluated_combination_df[col_name].astype(float)
 
+                    # A NaN here would silently poison the whole compound
+                    # weight vector (NaN * weight propagates through
+                    # np.average into every score), so fail loudly instead.
+                    # NaNs usually mean the weighted dataset (equity or
+                    # additional data) doesn't cover every demand location.
+                    if column_data.isna().any():
+                        raise ValueError(
+                            f"Cannot weight by '{label}': "
+                            f"{int(column_data.isna().sum())} demand row(s) "
+                            f"have missing values in '{col_name}'. This "
+                            "usually means the dataset does not cover every "
+                            "demand location. Please fill or filter the "
+                            f"missing values, or remove '{label}' from the "
+                            "weights dict."
+                        )
+
                     # if demand, assume higher_better
                     # if equity, get direction from equity data
                     direction = None

--- a/lokigi/site_solutions.py
+++ b/lokigi/site_solutions.py
@@ -213,17 +213,13 @@ class EvaluatedCombination:
                         )
 
                     elif label.lower() == "equity":
-                        # Equity weighting exists to prioritise WORSE-off
-                        # regions, so the row-weight direction is the
-                        # OPPOSITE of the equity value's "goodness": when
-                        # higher values mean better-off (e.g. IMD decile 10
-                        # = least deprived), lower values must receive the
-                        # higher weight, and vice versa for raw scores where
-                        # higher = more deprived.
+                        # Equity weighting exists to prioritise worse-off
+                        # regions, so whichever end of the equity scale is
+                        # disadvantaged is the end that gets the weight.
                         direction = (
                             "lower_better"
-                            if self.site_problem._equity_data_direction
-                            == "higher_is_better"
+                            if self.site_problem._equity_data_disadvantaged_end
+                            == "low"
                             else "higher_better"
                         )
 

--- a/lokigi/site_solutions.py
+++ b/lokigi/site_solutions.py
@@ -157,10 +157,28 @@ class EvaluatedCombination:
         # (a constant column would normalize to all-ones and have no
         # effect). It is excluded here and handled separately by the
         # solver's combination-comparison logic (see _apply_cost_weighting).
+        #
+        # "demand" and "equity" are canonicalised to lowercase here because
+        # this method can be reached directly (evaluate_single_solution_
+        # single_objective bypasses solve()'s own case-insensitive-but-
+        # unnormalised validation), and every comparison below -- the
+        # legacy-fallback check just below, and the col_name/direction
+        # resolution in the loop that follows -- is case-sensitive for
+        # these two built-in keywords. Without this, a differently-cased
+        # key like "Demand" silently matched no column, leaving the
+        # compound row weights all zero and crashing np.average with
+        # "Weights sum to zero". Additional-data labels are user-defined
+        # exact strings (not built-in keywords) and are deliberately left
+        # untouched -- they are matched case-sensitively against whatever
+        # was registered via add_additional_data(label=...).
         row_level_weights = (
             None
             if weights is None
-            else {k: v for k, v in weights.items() if k.lower() != "cost"}
+            else {
+                (k.lower() if k.lower() in ("demand", "equity") else k): v
+                for k, v in weights.items()
+                if k.lower() != "cost"
+            }
         )
 
         # If weights is purely the demand data, as was the default behaviour prior to 0.3.0,
@@ -191,44 +209,29 @@ class EvaluatedCombination:
             self.extra_metrics = {}
 
             for label, weight in row_level_weights.items():
-                # Map the user's label to the correct DataFrame column name
+                # Map the user's label to the correct DataFrame column name,
+                # and resolve its weighting direction, BEFORE checking that
+                # the column actually exists. This ordering matters: doing
+                # the existence check first (as a previous version of this
+                # code did) meant a genuinely unrecognised label -- one that
+                # doesn't match "demand", "equity", or any registered
+                # additional-data label -- had its column lookup silently
+                # fail and skipped the whole block instead of raising the
+                # "does not correspond to..." error below, leaving
+                # compound_weights all zero and crashing np.average with a
+                # confusing "Weights sum to zero" further down. Direct calls
+                # to evaluate_single_solution_single_objective (which skip
+                # solve()'s own case-insensitive key validation) are the
+                # main way this was reachable.
+                direction = None
+
                 if label == "demand":
                     col_name = self.site_problem._demand_data_demand_col
+                    direction = "higher_better"  # 'demand' defaults to higher_better
+
                 elif label == "equity":
                     col_name = self.site_problem._equity_data_equity_col
-                else:
-                    col_name = label
-
-                if col_name in self.evaluated_combination_df.columns:
-                    # Extract raw data
-                    column_data = self.evaluated_combination_df[col_name].astype(float)
-
-                    # A NaN here would silently poison the whole compound
-                    # weight vector (NaN * weight propagates through
-                    # np.average into every score), so fail loudly instead.
-                    # NaNs usually mean the weighted dataset (equity or
-                    # additional data) doesn't cover every demand location.
-                    if column_data.isna().any():
-                        raise ValueError(
-                            f"Cannot weight by '{label}': "
-                            f"{int(column_data.isna().sum())} demand row(s) "
-                            f"have missing values in '{col_name}'. This "
-                            "usually means the dataset does not cover every "
-                            "demand location. Please fill or filter the "
-                            f"missing values, or remove '{label}' from the "
-                            "weights dict."
-                        )
-
-                    # if demand, assume higher_better
-                    # if equity, get direction from equity data
-                    direction = None
-
-                    if label.lower() == "demand":
-                        direction = (
-                            "higher_better"  # 'demand' defaults to higher_better
-                        )
-
-                    elif label.lower() == "equity":
+                    if col_name is not None:
                         # Equity weighting exists to prioritise worse-off
                         # regions, so whichever end of the equity scale is
                         # disadvantaged is the end that gets the weight.
@@ -239,8 +242,10 @@ class EvaluatedCombination:
                             else "higher_better"
                         )
 
+                else:
+                    col_name = label
                     # Look up directionality from the problem configuration
-                    elif self.site_problem.additional_data is not None:
+                    if self.site_problem.additional_data is not None:
                         # Find the metadata dict matching this label
                         meta = next(
                             (
@@ -253,32 +258,55 @@ class EvaluatedCombination:
                         if meta:
                             direction = meta.get("direction", "higher_better")
 
-                    if direction is None:
-                        raise ValueError(
-                            f"Weight key '{label}' does not correspond to demand, "
-                            "equity, or any registered additional dataset. Register "
-                            "it via add_additional_data() first, or remove it from "
-                            "the weights dict."
-                        )
+                if (
+                    direction is None
+                    or col_name is None
+                    or col_name not in self.evaluated_combination_df.columns
+                ):
+                    raise ValueError(
+                        f"Weight key '{label}' does not correspond to demand, "
+                        "equity, or any registered additional dataset. Register "
+                        "it via add_additional_data() first, or remove it from "
+                        "the weights dict."
+                    )
 
-                    # Handle directionality by negating BEFORE normalising:
-                    # for lower_better this maps the smallest raw value to
-                    # 1.0 and the largest to 0.0 (identical to inverting
-                    # afterwards), but keeps the identical-values edge case
-                    # on the equal (full) baseline weight from constant_fill.
-                    # Inverting after normalising would turn that neutral
-                    # 1.0 into an all-zero weight vector and crash
-                    # np.average with "Weights sum to zero".
-                    if direction == "lower_better":
-                        column_data = -column_data
+                # Extract raw data
+                column_data = self.evaluated_combination_df[col_name].astype(float)
 
-                    # Min-Max Normalization to a 0.0 - 1.0 scale. Edge case:
-                    # if all values are identical, give them equal (full)
-                    # baseline weight rather than 0.
-                    norm_data = _min_max_normalize(column_data, constant_fill=1.0)
+                # A NaN here would silently poison the whole compound
+                # weight vector (NaN * weight propagates through
+                # np.average into every score), so fail loudly instead.
+                # NaNs usually mean the weighted dataset (equity or
+                # additional data) doesn't cover every demand location.
+                if column_data.isna().any():
+                    raise ValueError(
+                        f"Cannot weight by '{label}': "
+                        f"{int(column_data.isna().sum())} demand row(s) "
+                        f"have missing values in '{col_name}'. This "
+                        "usually means the dataset does not cover every "
+                        "demand location. Please fill or filter the "
+                        f"missing values, or remove '{label}' from the "
+                        "weights dict."
+                    )
 
-                    # Accumulate the normalized, directional weight
-                    compound_weights += norm_data * weight
+                # Handle directionality by negating BEFORE normalising: for
+                # lower_better this maps the smallest raw value to 1.0 and
+                # the largest to 0.0 (identical to inverting afterwards),
+                # but keeps the identical-values edge case on the equal
+                # (full) baseline weight from constant_fill. Inverting
+                # after normalising would turn that neutral 1.0 into an
+                # all-zero weight vector and crash np.average with
+                # "Weights sum to zero".
+                if direction == "lower_better":
+                    column_data = -column_data
+
+                # Min-Max Normalization to a 0.0 - 1.0 scale. Edge case: if
+                # all values are identical, give them equal (full) baseline
+                # weight rather than 0.
+                norm_data = _min_max_normalize(column_data, constant_fill=1.0)
+
+                # Accumulate the normalized, directional weight
+                compound_weights += norm_data * weight
 
             # Calculate the final composite weighted average across all objectives
             self.weighted_average = np.average(

--- a/lokigi/site_solutions.py
+++ b/lokigi/site_solutions.py
@@ -203,11 +203,6 @@ class EvaluatedCombination:
                     # Extract raw data
                     column_data = self.evaluated_combination_df[col_name].astype(float)
 
-                    # Min-Max Normalization to a 0.0 - 1.0 scale. Edge case:
-                    # if all values are identical, give them equal (full)
-                    # baseline weight rather than 0.
-                    norm_data = _min_max_normalize(column_data, constant_fill=1.0)
-
                     # if demand, assume higher_better
                     # if equity, get direction from equity data
                     direction = None
@@ -218,12 +213,19 @@ class EvaluatedCombination:
                         )
 
                     elif label.lower() == "equity":
+                        # Equity weighting exists to prioritise WORSE-off
+                        # regions, so the row-weight direction is the
+                        # OPPOSITE of the equity value's "goodness": when
+                        # higher values mean better-off (e.g. IMD decile 10
+                        # = least deprived), lower values must receive the
+                        # higher weight, and vice versa for raw scores where
+                        # higher = more deprived.
                         direction = (
-                            "higher_better"
+                            "lower_better"
                             if self.site_problem._equity_data_direction
                             == "higher_is_better"
-                            else "lower_better"
-                        )  # 'demand' defaults to higher_better
+                            else "higher_better"
+                        )
 
                     # Look up directionality from the problem configuration
                     elif self.site_problem.additional_data is not None:
@@ -247,9 +249,21 @@ class EvaluatedCombination:
                             "the weights dict."
                         )
 
-                    # Handle Directionality (Invert weights if lower_better)
+                    # Handle directionality by negating BEFORE normalising:
+                    # for lower_better this maps the smallest raw value to
+                    # 1.0 and the largest to 0.0 (identical to inverting
+                    # afterwards), but keeps the identical-values edge case
+                    # on the equal (full) baseline weight from constant_fill.
+                    # Inverting after normalising would turn that neutral
+                    # 1.0 into an all-zero weight vector and crash
+                    # np.average with "Weights sum to zero".
                     if direction == "lower_better":
-                        norm_data = 1.0 - norm_data
+                        column_data = -column_data
+
+                    # Min-Max Normalization to a 0.0 - 1.0 scale. Edge case:
+                    # if all values are identical, give them equal (full)
+                    # baseline weight rather than 0.
+                    norm_data = _min_max_normalize(column_data, constant_fill=1.0)
 
                     # Accumulate the normalized, directional weight
                     compound_weights += norm_data * weight

--- a/lokigi/utils.py
+++ b/lokigi/utils.py
@@ -279,6 +279,33 @@ def _validate_columns(
         )
 
 
+def _get_required_site_indices(site_problem) -> list:
+    """
+    Integer positions of candidate sites flagged as required via
+    `add_sites(required_sites_col=...)`, or an empty list if no required
+    sites column is configured.
+
+    Flag values are matched case-insensitively against a set of sensible
+    "truthy" markers, so the column may hold booleans, integers, or messy
+    strings ("Y", " true ", 1, ...).
+    """
+    if site_problem is None or site_problem._candidate_sites_required_sites_col is None:
+        return []
+
+    truthy_values = {"y", "yes", "true", "t", "required", "1"}
+
+    col_data = (
+        site_problem.candidate_sites[site_problem._candidate_sites_required_sites_col]
+        .astype(str)
+        .str.lower()
+        .str.strip()
+    )
+
+    is_required = col_data.isin(truthy_values)
+
+    return [int(i) for i in np.where(is_required)[0]]
+
+
 def _generate_all_combinations(
     n_facilities: int, p: int, site_problem=None, force_include_indices=None
 ) -> list:
@@ -327,29 +354,10 @@ def _generate_all_combinations(
     #     )
 
     if site_problem is not None:
-        if site_problem._candidate_sites_required_sites_col is not None:
-            # Define a set of sensible "truthy" values (all lowercase)
-            truthy_values = {"y", "yes", "true", "t", "required", "1"}
-
-            # Normalize the column data: convert to string, lowercase, and strip whitespace
-            # This prevents errors if the column contains actual booleans, integers, or messy strings
-            col_data = (
-                site_problem.candidate_sites[
-                    site_problem._candidate_sites_required_sites_col
-                ]
-                .astype(str)
-                .str.lower()
-                .str.strip()
-            )
-
-            # Create the boolean mask using .isin()
-            is_required = col_data.isin(truthy_values)
-
-            # Extract the integer indices (e.g., [0, 1, 2])
-            site_indices = np.where(is_required)[0]
-
+        required_indices = _get_required_site_indices(site_problem)
+        if required_indices:
             # Convert required indices to a set for O(1) lookups
-            required_set = set(site_indices)
+            required_set = set(required_indices)
 
             # Filter the combinations to only keep those containing ALL required sites
             result = [a for a in result if required_set.issubset(a)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lokigi"
-version = "0.4.0"
+version = "0.4.1"
 description = "A package for generating, ranking, analysing and visualising the best candidate solutions for discrete facility location problems"
 readme = "README.md"
 license = "MIT"

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,46 @@ numbers. `brighton_problem` is the exception: it loads real data from
 `sample_data/brighton_*` (CSV demand, geojson candidate sites, CSV travel
 matrix), for coverage of the CSV/geojson loading path.
 
+## Fixture and assertion conventions
+
+Most fixtures in this suite follow three related conventions, worth keeping
+up when adding new ones:
+
+**Hand-checkable numbers, not arbitrary ones.** Fixture travel times, demand,
+and costs are chosen so the expected result can be derived by hand (or with
+a calculator) and asserted as an exact value, rather than just checking
+"solve() returns *something* plausible." E.g. equity-weighted fixtures in
+[test_equity_weighting_direction.py](test_equity_weighting_direction.py)
+assert exact fractions like `145/14`; the cost/travel tradeoff in
+[conftest.py](conftest.py)'s `cost_weighted_pruning_problem` is chosen so
+the true cost-weighted winner is obvious by inspection (one site cheap and
+slow, others fast and expensive). Prefer this over hardcoding whatever a
+first correct run happens to output -- an independently-derived number
+catches bugs that both the code and a copied-from-output assertion would
+agree on.
+
+**Sanity-check that adversarial fixtures actually discriminate.** When a
+fixture is built to separate two things that usually agree (e.g.
+`five_site_problem` in [conftest.py](conftest.py), where the best
+`weighted_average` combination is deliberately *not* the best `mclp`
+coverage combination), pair it with a small test that pins the
+un-confounded baseline -- e.g.
+`test_unconstrained_greedy_walks_into_the_trap` in
+[test_max_value_cutoff_strategies.py](test_max_value_cutoff_strategies.py)
+confirms unconstrained greedy actually walks into the trap before the
+cutoff-respecting tests rely on that trap existing. If the fixture stops
+discriminating (e.g. after an unrelated change), this fails loudly instead
+of every dependent test silently passing for the wrong reason.
+
+**"Trap" fixtures engineered to catch a specific plausible-but-wrong
+implementation.** Rather than a generic random problem, several fixtures
+(`greedy_trap_problem`, `cost_weighted_pruning_problem`,
+`tied_score_problem`) are shaped so that one specific incorrect behaviour
+-- a myopic greedy choice, cost-blind pruning, an unhandled exact tie --
+produces a *different, checkable* answer than the correct implementation.
+This makes the test a real pin against that exact failure mode, not just a
+smoke test that happens to also exercise the code path.
+
 ## Backtests (`test_backtests.py`)
 
 Most test files check *correctness* -- they hand-derive the expected answer

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,79 @@
+# Tests
+
+## Running the suite
+
+From the repo root, with the project's dev environment installed (`uv sync` /
+`pip install -e ".[dev]"` or equivalent):
+
+```
+pytest
+```
+
+`pytest.ini` points `testpaths` at this directory, so `pytest` from the repo
+root is equivalent to `pytest tests/`. Useful variants:
+
+```
+pytest tests/test_search_strategies.py     # one file
+pytest -k mclp                              # anything matching "mclp"
+pytest -x                                   # stop at the first failure
+pytest -q                                   # quiet output
+```
+
+Fixtures shared across test files (sample `SiteProblem`s, demand/candidate/
+travel `DataFrame`s, etc.) live in [conftest.py](conftest.py). Most fixtures
+build small synthetic problems inline with hand-computable travel times, so
+that "known solution" tests can assert against independently derived
+numbers. `brighton_problem` is the exception: it loads real data from
+`sample_data/brighton_*` (CSV demand, geojson candidate sites, CSV travel
+matrix), for coverage of the CSV/geojson loading path.
+
+## Backtests (`test_backtests.py`)
+
+Most test files check *correctness* -- they hand-derive the expected answer
+for a small problem and assert `solve()` matches it. `test_backtests.py` is
+different: it's a regression/snapshot suite that pins `solve()`'s *current*
+output for a spread of fixtures and solver configurations (brute-force,
+greedy, grasp; p_median, p_center, mclp, hybrid; synthetic and
+`brighton_problem`), so that an unintended change to solver internals shows
+up as a failing test even when it doesn't happen to break one of the
+narrower correctness checks.
+
+Expected values are **not** hardcoded in the test file. They live in
+[backtest_snapshots.json](backtest_snapshots.json), keyed by test name, and
+are compared via the `assert_backtest` fixture (defined in
+[conftest.py](conftest.py)).
+
+### When to regenerate
+
+Only when a change to `solve()`, an objective, or a search strategy is
+**intentional** and you've confirmed the new numbers are correct -- e.g.
+after a deliberate algorithm change, not as a way to silence a failure you
+don't understand. If a backtest fails and you didn't expect solver output to
+change, treat it as a real regression and investigate before touching the
+snapshot.
+
+### How to regenerate
+
+```
+pytest tests/test_backtests.py --update-backtests
+```
+
+This recomputes every backtest case and overwrites
+`tests/backtest_snapshots.json`. Then:
+
+```
+git diff tests/backtest_snapshots.json
+```
+
+Review the diff -- it's the entire review surface for "did this change
+solver behaviour, and is that expected?". Only commit the updated snapshot
+file once the diff looks right.
+
+### Adding a new backtest case
+
+Add a test function to `test_backtests.py` that calls `solve()` (or another
+solver entry point) on an existing or new fixture, builds a fingerprint with
+`_fingerprint(result, cols=...)`, and passes it to `assert_backtest(...)` --
+no expected value needed in the test itself. Then run with
+`--update-backtests` once to create its entry in `backtest_snapshots.json`,
+and check the generated values look sane before committing.

--- a/tests/backtest_snapshots.json
+++ b/tests/backtest_snapshots.json
@@ -1,0 +1,722 @@
+{
+  "test_backtest_brighton_problem_mclp_brute_force": [
+    [
+      [
+        "Site 3",
+        "Site 4"
+      ],
+      1.0
+    ],
+    [
+      [
+        "Site 3",
+        "Site 6"
+      ],
+      1.0
+    ],
+    [
+      [
+        "Site 1",
+        "Site 3"
+      ],
+      1.0
+    ],
+    [
+      [
+        "Site 3",
+        "Site 5"
+      ],
+      1.0
+    ],
+    [
+      [
+        "Site 2",
+        "Site 3"
+      ],
+      1.0
+    ],
+    [
+      [
+        "Site 4",
+        "Site 5"
+      ],
+      0.993939
+    ],
+    [
+      [
+        "Site 5",
+        "Site 6"
+      ],
+      0.993939
+    ],
+    [
+      [
+        "Site 1",
+        "Site 5"
+      ],
+      0.993939
+    ],
+    [
+      [
+        "Site 2",
+        "Site 5"
+      ],
+      0.993939
+    ],
+    [
+      [
+        "Site 2",
+        "Site 4"
+      ],
+      0.987879
+    ],
+    [
+      [
+        "Site 4",
+        "Site 6"
+      ],
+      0.987879
+    ],
+    [
+      [
+        "Site 2",
+        "Site 6"
+      ],
+      0.987879
+    ],
+    [
+      [
+        "Site 1",
+        "Site 2"
+      ],
+      0.987879
+    ],
+    [
+      [
+        "Site 1",
+        "Site 6"
+      ],
+      0.987879
+    ],
+    [
+      [
+        "Site 1",
+        "Site 4"
+      ],
+      0.969697
+    ]
+  ],
+  "test_backtest_brighton_problem_p_center_brute_force": [
+    [
+      [
+        "Site 3",
+        "Site 4"
+      ],
+      16.688833
+    ],
+    [
+      [
+        "Site 3",
+        "Site 6"
+      ],
+      16.688833
+    ],
+    [
+      [
+        "Site 1",
+        "Site 3"
+      ],
+      16.688833
+    ],
+    [
+      [
+        "Site 3",
+        "Site 5"
+      ],
+      16.688833
+    ],
+    [
+      [
+        "Site 2",
+        "Site 3"
+      ],
+      16.688833
+    ],
+    [
+      [
+        "Site 4",
+        "Site 5"
+      ],
+      21.709667
+    ],
+    [
+      [
+        "Site 5",
+        "Site 6"
+      ],
+      21.709667
+    ],
+    [
+      [
+        "Site 1",
+        "Site 5"
+      ],
+      21.709667
+    ],
+    [
+      [
+        "Site 2",
+        "Site 5"
+      ],
+      21.709667
+    ],
+    [
+      [
+        "Site 4",
+        "Site 6"
+      ],
+      22.857667
+    ],
+    [
+      [
+        "Site 2",
+        "Site 6"
+      ],
+      22.857667
+    ],
+    [
+      [
+        "Site 1",
+        "Site 6"
+      ],
+      22.857667
+    ],
+    [
+      [
+        "Site 2",
+        "Site 4"
+      ],
+      23.921
+    ],
+    [
+      [
+        "Site 1",
+        "Site 2"
+      ],
+      23.921
+    ],
+    [
+      [
+        "Site 1",
+        "Site 4"
+      ],
+      26.329833
+    ]
+  ],
+  "test_backtest_brighton_problem_p_median_brute_force_top5": [
+    [
+      [
+        "Site 3",
+        "Site 4",
+        "Site 5"
+      ],
+      5.372208,
+      16.688833,
+      5.447841
+    ],
+    [
+      [
+        "Site 3",
+        "Site 4",
+        "Site 6"
+      ],
+      5.376954,
+      16.688833,
+      5.357941
+    ],
+    [
+      [
+        "Site 1",
+        "Site 3",
+        "Site 4"
+      ],
+      5.531092,
+      16.688833,
+      5.672539
+    ],
+    [
+      [
+        "Site 2",
+        "Site 3",
+        "Site 4"
+      ],
+      5.544051,
+      16.688833,
+      5.594884
+    ],
+    [
+      [
+        "Site 1",
+        "Site 3",
+        "Site 6"
+      ],
+      6.323543,
+      16.688833,
+      6.213082
+    ]
+  ],
+  "test_backtest_brighton_problem_p_median_grasp": [
+    [
+      [
+        "Site 3",
+        "Site 4",
+        "Site 5"
+      ],
+      5.372208,
+      16.688833,
+      5.447841
+    ],
+    [
+      [
+        "Site 3",
+        "Site 4",
+        "Site 6"
+      ],
+      5.376954,
+      16.688833,
+      5.357941
+    ]
+  ],
+  "test_backtest_brighton_problem_p_median_greedy": [
+    [
+      [
+        "Site 3",
+        "Site 4",
+        "Site 5"
+      ],
+      5.372208,
+      16.688833,
+      5.447841
+    ]
+  ],
+  "test_backtest_five_site_problem_mclp_brute_force": [
+    [
+      [
+        "Site_1",
+        "Site_3"
+      ],
+      0.75
+    ],
+    [
+      [
+        "Site_2",
+        "Site_3"
+      ],
+      0.75
+    ],
+    [
+      [
+        "Site_3",
+        "Site_5"
+      ],
+      0.5
+    ],
+    [
+      [
+        "Site_3",
+        "Site_4"
+      ],
+      0.5
+    ],
+    [
+      [
+        "Site_2",
+        "Site_4"
+      ],
+      0.25
+    ],
+    [
+      [
+        "Site_1",
+        "Site_5"
+      ],
+      0.25
+    ],
+    [
+      [
+        "Site_1",
+        "Site_4"
+      ],
+      0.25
+    ],
+    [
+      [
+        "Site_2",
+        "Site_5"
+      ],
+      0.25
+    ],
+    [
+      [
+        "Site_1",
+        "Site_2"
+      ],
+      0.25
+    ],
+    [
+      [
+        "Site_4",
+        "Site_5"
+      ],
+      0.0
+    ]
+  ],
+  "test_backtest_five_site_problem_p_center_brute_force": [
+    [
+      [
+        "Site_3",
+        "Site_5"
+      ],
+      17.0
+    ],
+    [
+      [
+        "Site_4",
+        "Site_5"
+      ],
+      17.0
+    ],
+    [
+      [
+        "Site_1",
+        "Site_3"
+      ],
+      24.0
+    ],
+    [
+      [
+        "Site_2",
+        "Site_3"
+      ],
+      24.0
+    ],
+    [
+      [
+        "Site_3",
+        "Site_4"
+      ],
+      24.0
+    ],
+    [
+      [
+        "Site_2",
+        "Site_4"
+      ],
+      25.0
+    ],
+    [
+      [
+        "Site_1",
+        "Site_5"
+      ],
+      28.0
+    ],
+    [
+      [
+        "Site_1",
+        "Site_2"
+      ],
+      28.0
+    ],
+    [
+      [
+        "Site_1",
+        "Site_4"
+      ],
+      29.0
+    ],
+    [
+      [
+        "Site_2",
+        "Site_5"
+      ],
+      31.0
+    ]
+  ],
+  "test_backtest_five_site_problem_p_median_brute_force": [
+    [
+      [
+        "Site_1",
+        "Site_3"
+      ],
+      15.0,
+      24.0,
+      15.0
+    ],
+    [
+      [
+        "Site_3",
+        "Site_5"
+      ],
+      15.0,
+      17.0,
+      15.0
+    ],
+    [
+      [
+        "Site_2",
+        "Site_3"
+      ],
+      15.25,
+      24.0,
+      15.25
+    ],
+    [
+      [
+        "Site_4",
+        "Site_5"
+      ],
+      16.25,
+      17.0,
+      16.25
+    ],
+    [
+      [
+        "Site_3",
+        "Site_4"
+      ],
+      16.75,
+      24.0,
+      16.75
+    ],
+    [
+      [
+        "Site_2",
+        "Site_4"
+      ],
+      17.0,
+      25.0,
+      17.0
+    ],
+    [
+      [
+        "Site_1",
+        "Site_5"
+      ],
+      17.5,
+      28.0,
+      17.5
+    ],
+    [
+      [
+        "Site_1",
+        "Site_4"
+      ],
+      17.75,
+      29.0,
+      17.75
+    ],
+    [
+      [
+        "Site_2",
+        "Site_5"
+      ],
+      18.5,
+      31.0,
+      18.5
+    ],
+    [
+      [
+        "Site_1",
+        "Site_2"
+      ],
+      20.25,
+      28.0,
+      20.25
+    ]
+  ],
+  "test_backtest_five_site_problem_p_median_grasp": [
+    [
+      [
+        "Site_3",
+        "Site_5"
+      ],
+      15.0,
+      17.0,
+      15.0
+    ],
+    [
+      [
+        "Site_1",
+        "Site_3"
+      ],
+      15.0,
+      24.0,
+      15.0
+    ],
+    [
+      [
+        "Site_4",
+        "Site_5"
+      ],
+      16.25,
+      17.0,
+      16.25
+    ]
+  ],
+  "test_backtest_five_site_problem_p_median_greedy": [
+    [
+      [
+        "Site_4",
+        "Site_5"
+      ],
+      16.25,
+      17.0,
+      16.25
+    ]
+  ],
+  "test_backtest_hybrid_p_median_problem_brute_force": [
+    [
+      [
+        "Site_1",
+        "Site_2"
+      ],
+      7.0,
+      10.0,
+      7.0
+    ]
+  ],
+  "test_backtest_loaded_problem_p_median_brute_force": [
+    [
+      [
+        "Site_A",
+        "Site_C"
+      ],
+      9.333333,
+      10.0,
+      9.333333
+    ],
+    [
+      [
+        "Site_A",
+        "Site_B"
+      ],
+      9.444444,
+      15.0,
+      10.0
+    ],
+    [
+      [
+        "Site_B",
+        "Site_C"
+      ],
+      10.444444,
+      25.0,
+      12.666667
+    ]
+  ],
+  "test_backtest_loaded_problem_p_median_grasp": [
+    [
+      [
+        "Site_A",
+        "Site_C"
+      ],
+      9.333333,
+      10.0,
+      9.333333
+    ],
+    [
+      [
+        "Site_A",
+        "Site_B"
+      ],
+      9.444444,
+      15.0,
+      10.0
+    ]
+  ],
+  "test_backtest_loaded_problem_p_median_greedy": [
+    [
+      [
+        "Site_A",
+        "Site_B"
+      ],
+      9.444444,
+      15.0,
+      10.0
+    ]
+  ],
+  "test_backtest_loaded_problem_with_cost_weighted_p_median": [
+    [
+      [
+        "Site_A",
+        "Site_C"
+      ],
+      9.333333,
+      60.0
+    ],
+    [
+      [
+        "Site_A",
+        "Site_B"
+      ],
+      9.444444,
+      510.0
+    ],
+    [
+      [
+        "Site_B",
+        "Site_C"
+      ],
+      10.444444,
+      550.0
+    ]
+  ],
+  "test_backtest_loaded_problem_with_equity_weighted_p_median": [
+    [
+      [
+        "Site_A",
+        "Site_B"
+      ],
+      8.272727,
+      15.0,
+      10.0
+    ],
+    [
+      [
+        "Site_A",
+        "Site_C"
+      ],
+      9.672727,
+      10.0,
+      9.333333
+    ],
+    [
+      [
+        "Site_B",
+        "Site_C"
+      ],
+      12.036364,
+      25.0,
+      12.666667
+    ]
+  ],
+  "test_backtest_tied_score_problem_p_median_brute_force_keep_best_n": [
+    [
+      [
+        "Site_C"
+      ],
+      10.0,
+      15.0,
+      10.0
+    ],
+    [
+      [
+        "Site_B"
+      ],
+      15.0,
+      20.0,
+      15.0
+    ]
+  ]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,6 +407,138 @@ def tied_score_problem():
 
 
 @pytest.fixture
+def tied_score_problem_with_cost():
+    """
+    Same shape as `tied_score_problem` (Site_A and Site_B tie exactly on
+    weighted_average, both 15.0, with Site_C clearly better at 10.0), but
+    with a `build_cost` column added where Site_A and Site_B also share an
+    identical cost. That keeps them tied on `composite_score` even after
+    cost weighting is blended in, so the cost-weighted keep_best_n/
+    keep_worst_n path (pandas `nsmallest`/`nlargest`) can be checked for
+    the same exact-tie scenario that used to crash the heap-based path.
+    """
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_1", "LSOA_2"],
+            "demand": [100, 100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_A", "Site_B", "Site_C"],
+            "lat": [51.1, 51.2, 51.3],
+            "long": [-0.1, -0.2, -0.3],
+            "build_cost": [5.0, 5.0, 1.0],
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_1", "LSOA_2"],
+            "Site_A": [10.0, 20.0],
+            "Site_B": [10.0, 20.0],
+            "Site_C": [5.0, 15.0],
+        }
+    )
+
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(candidate_df, candidate_id_col="site_id", cost_col="build_cost")
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+@pytest.fixture
+def cost_weighted_pruning_problem():
+    """
+    A 4-site/1-demand-point problem (p=1) built so that the combination
+    with the true cost-weighted-best score has the WORST raw (pre-cost)
+    weighted_average, dead last of 4:
+
+      Site_Fast1: travel=5,  build_cost=1000.0
+      Site_Fast2: travel=6,  build_cost=1000.0
+      Site_Mid:   travel=12, build_cost=1000.0
+      Site_Cheap: travel=15, build_cost=1.0    <- worst raw ranking, cheapest
+
+    With weights={"demand": 0.05, "cost": 0.95}, Site_Cheap is the true
+    winner once cost dominates -- but a brute_force_keep_best_n heap that
+    prunes on the raw ranking value (before cost is blended in) would
+    discard Site_Cheap immediately, since it ranks last of 4 on
+    weighted_average alone.
+    """
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["L1"],
+            "demand": [100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_Fast1", "Site_Fast2", "Site_Mid", "Site_Cheap"],
+            "lat": [51.1, 51.2, 51.3, 51.4],
+            "long": [-0.1, -0.2, -0.3, -0.4],
+            "build_cost": [1000.0, 1000.0, 1000.0, 1.0],
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["L1"],
+            "Site_Fast1": [5.0],
+            "Site_Fast2": [6.0],
+            "Site_Mid": [12.0],
+            "Site_Cheap": [15.0],
+        }
+    )
+
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(candidate_df, candidate_id_col="site_id", cost_col="build_cost")
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+@pytest.fixture
+def cost_weighted_five_site_problem():
+    """
+    Like `five_site_problem` (5 sites, 4 demand points, p=2, 10 possible
+    combinations), but with a `build_cost` column added whose cheapest
+    sites are not the sites with the best raw travel times -- so
+    cost-weighted brute-force search is a genuinely different ranking than
+    the unweighted one, giving a non-trivial adversarial case for
+    comparing a pruned (brute_force_keep_best_n) run against a full run.
+    """
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "demand": [100, 100, 100, 100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_1", "Site_2", "Site_3", "Site_4", "Site_5"],
+            "lat": [51.1, 51.2, 51.3, 51.4, 51.5],
+            "long": [-0.1, -0.2, -0.3, -0.4, -0.5],
+            "build_cost": [50.0, 10.0, 30.0, 5.0, 100.0],
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "Site_1": [38.0, 18.0, 10.0, 28.0],
+            "Site_2": [25.0, 40.0, 11.0, 31.0],
+            "Site_3": [24.0, 13.0, 29.0, 13.0],
+            "Site_4": [29.0, 16.0, 17.0, 16.0],
+            "Site_5": [17.0, 15.0, 17.0, 36.0],
+        }
+    )
+
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(candidate_df, candidate_id_col="site_id", cost_col="build_cost")
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+@pytest.fixture
 def hybrid_p_median_problem():
     """
     A 3-site/4-demand-point problem (p=2, 3 possible combinations) built so

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -457,13 +457,13 @@ def equity_df():
 @pytest.fixture
 def loaded_problem_with_equity(loaded_problem, equity_df):
     """`loaded_problem` with equity data wired in via add_equity_data().
-    IMD deciles: 10 = least deprived, so higher is better."""
+    IMD deciles: 1 = most deprived, so the disadvantaged end is low."""
     loaded_problem.add_equity_data(
         equity_df,
         equity_col="imd_decile",
         common_col="location_id",
         label="equity",
-        direction="higher_is_better",
+        disadvantaged_end="low",
     )
     return loaded_problem
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,88 @@
+import json
+from pathlib import Path
+
 import pytest
 import lokigi
 import pandas as pd
 from shapely.geometry import Point
 import geopandas
+
+
+# --- Backtest snapshot machinery (see tests/test_backtests.py) ---
+#
+# Backtests pin solve()'s current output rather than independently deriving
+# it, so updating them by hand means re-running each case and re-typing
+# numbers into the test file. Instead, expected values live in
+# tests/backtest_snapshots.json, and `pytest --update-backtests` regenerates
+# that file from whatever solve() currently returns.
+
+BACKTEST_SNAPSHOT_PATH = Path(__file__).parent / "backtest_snapshots.json"
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--update-backtests",
+        action="store_true",
+        default=False,
+        help=(
+            "Regenerate tests/backtest_snapshots.json from solve()'s current "
+            "output instead of asserting against the stored snapshot. Use "
+            "after a deliberate change to solver behaviour; review the diff "
+            "before committing it."
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def _backtest_snapshot_store(request):
+    if BACKTEST_SNAPSHOT_PATH.exists():
+        snapshots = json.loads(BACKTEST_SNAPSHOT_PATH.read_text())
+    else:
+        snapshots = {}
+    updates = {}
+    yield snapshots, updates, request.config.getoption("--update-backtests")
+    if updates:
+        snapshots.update(updates)
+        BACKTEST_SNAPSHOT_PATH.write_text(
+            json.dumps(snapshots, indent=2, sort_keys=True) + "\n"
+        )
+
+
+@pytest.fixture
+def assert_backtest(_backtest_snapshot_store, request):
+    """Compare a fingerprint (see test_backtests.py::_fingerprint) against its
+    stored snapshot, keyed by the calling test's node id. In
+    `--update-backtests` mode, records the current value to be written to
+    tests/backtest_snapshots.json once the session finishes instead."""
+    snapshots, updates, update_mode = _backtest_snapshot_store
+
+    def _normalize(value):
+        """Recursively convert tuples to lists so a freshly computed
+        fingerprint compares equal to one that's round-tripped through JSON
+        (which has no tuple type)."""
+        if isinstance(value, (tuple, list)):
+            return [_normalize(item) for item in value]
+        return value
+
+    def _assert(fingerprint):
+        key = request.node.name
+        normalized = _normalize(fingerprint)
+        if update_mode:
+            updates[key] = normalized
+            return
+        expected = snapshots.get(key)
+        assert expected is not None, (
+            f"No stored backtest snapshot for {key!r}. Run "
+            "`pytest tests/test_backtests.py --update-backtests` to create it, "
+            "then review tests/backtest_snapshots.json before committing."
+        )
+        assert normalized == expected, (
+            f"Backtest {key!r} drifted from its stored snapshot in "
+            "tests/backtest_snapshots.json. If this is an intentional solver "
+            "change, rerun with --update-backtests and review the diff."
+        )
+
+    return _assert
 
 
 @pytest.fixture

--- a/tests/test_backtests.py
+++ b/tests/test_backtests.py
@@ -1,0 +1,247 @@
+"""
+Backtests / regression snapshots.
+
+Unlike the hand-computed "known solution" tests elsewhere in this suite,
+these tests don't independently verify correctness -- they pin the exact
+output of `solve()` for a fixed set of sample problems (both the small
+synthetic fixtures in conftest.py and the CSV/geojson-backed
+`brighton_problem`) and known solver configurations, so that any future
+change to solver internals which alters results shows up as a failing test
+here, even if it doesn't happen to violate one of the narrower correctness
+checks.
+
+Expected values are NOT hardcoded here -- they live in
+tests/backtest_snapshots.json, keyed by test name, via the `assert_backtest`
+fixture (defined in conftest.py). If a change to `solve()`, its objectives,
+or search strategies is intentional and the new numbers are believed to be
+correct, regenerate the snapshots instead of hand-editing them:
+
+    pytest tests/test_backtests.py --update-backtests
+
+...then review the resulting diff in tests/backtest_snapshots.json before
+committing it.
+
+Each fixture/config pair captures:
+  - the ordered list of returned site combinations (order encodes ranking,
+    so a ranking regression is caught even if individual scores don't move)
+  - a handful of key metric columns per row, rounded to 6dp to absorb
+    floating point noise across platforms/numpy versions.
+
+Written by Claude Opus 4.8
+"""
+
+import pandas as pd
+
+
+def _fingerprint(result, cols=("weighted_average", "max", "unweighted_average")):
+    """Order-preserving, tuple-based snapshot of a SiteSolutionSet.solution_df:
+    one tuple per solution row, in the order solve() ranked them, of
+    (sorted site names, *requested metric columns rounded to 6dp)."""
+    rows = []
+    for _, row in result.solution_df.iterrows():
+        entry = [tuple(sorted(row["site_names"]))]
+        for col in cols:
+            value = row[col]
+            entry.append(round(float(value), 6) if pd.notna(value) else None)
+        rows.append(tuple(entry))
+    return rows
+
+
+# --- loaded_problem (3 sites / 3 demand points, synthetic) ---
+
+
+def test_backtest_loaded_problem_p_median_brute_force(loaded_problem, assert_backtest):
+    result = loaded_problem.solve(
+        p=2, objectives="p_median", search_strategy="brute-force", show_progress=False
+    )
+    assert_backtest(_fingerprint(result))
+
+
+def test_backtest_loaded_problem_p_median_greedy(loaded_problem, assert_backtest):
+    result = loaded_problem.solve(
+        p=2, objectives="p_median", search_strategy="greedy", show_progress=False
+    )
+    assert_backtest(_fingerprint(result))
+
+
+def test_backtest_loaded_problem_p_median_grasp(loaded_problem, assert_backtest):
+    result = loaded_problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=3,
+    )
+    assert_backtest(_fingerprint(result))
+
+
+# --- five_site_problem (5 sites / 4 demand points, adversarial travel times) ---
+
+
+def test_backtest_five_site_problem_p_median_brute_force(
+    five_site_problem, assert_backtest
+):
+    result = five_site_problem.solve(
+        p=2, objectives="p_median", search_strategy="brute-force", show_progress=False
+    )
+    assert_backtest(_fingerprint(result))
+
+
+def test_backtest_five_site_problem_p_center_brute_force(
+    five_site_problem, assert_backtest
+):
+    result = five_site_problem.solve(
+        p=2, objectives="p_center", search_strategy="brute-force", show_progress=False
+    )
+    assert_backtest(_fingerprint(result, cols=("max",)))
+
+
+def test_backtest_five_site_problem_mclp_brute_force(five_site_problem, assert_backtest):
+    result = five_site_problem.solve(
+        p=2,
+        objectives="mclp",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=15,
+    )
+    assert_backtest(
+        _fingerprint(result, cols=("proportion_within_coverage_threshold",))
+    )
+
+
+def test_backtest_five_site_problem_p_median_greedy(five_site_problem, assert_backtest):
+    result = five_site_problem.solve(
+        p=2, objectives="p_median", search_strategy="greedy", show_progress=False
+    )
+    assert_backtest(_fingerprint(result))
+
+
+def test_backtest_five_site_problem_p_median_grasp(five_site_problem, assert_backtest):
+    result = five_site_problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=3,
+    )
+    assert_backtest(_fingerprint(result))
+
+
+# --- tied_score_problem: exact-tie ordering through the keep_best_n heap ---
+
+
+def test_backtest_tied_score_problem_p_median_brute_force_keep_best_n(
+    tied_score_problem, assert_backtest
+):
+    result = tied_score_problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        brute_force_keep_best_n=2,
+    )
+    assert_backtest(_fingerprint(result))
+
+
+# --- hybrid_p_median_problem: max_value_cutoff safety net ---
+
+
+def test_backtest_hybrid_p_median_problem_brute_force(
+    hybrid_p_median_problem, assert_backtest
+):
+    result = hybrid_p_median_problem.solve(
+        p=2,
+        objectives="hybrid_p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        max_value_cutoff=10,
+    )
+    assert_backtest(_fingerprint(result))
+
+
+# --- loaded_problem_with_cost: weighted p_median with a cost component ---
+
+
+def test_backtest_loaded_problem_with_cost_weighted_p_median(
+    loaded_problem_with_cost, assert_backtest
+):
+    result = loaded_problem_with_cost.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"demand": 0.5, "cost": 0.5},
+    )
+    assert_backtest(_fingerprint(result, cols=("weighted_average", "total_cost")))
+
+
+# --- loaded_problem_with_equity: weighted p_median with a demand+equity blend ---
+
+
+def test_backtest_loaded_problem_with_equity_weighted_p_median(
+    loaded_problem_with_equity, assert_backtest
+):
+    result = loaded_problem_with_equity.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"demand": 0.5, "equity": 0.5},
+    )
+    assert_backtest(_fingerprint(result))
+
+
+# --- brighton_problem: real CSV demand/travel matrix + geojson candidate sites ---
+
+
+def test_backtest_brighton_problem_p_median_brute_force_top5(
+    brighton_problem, assert_backtest
+):
+    result = brighton_problem.solve(
+        p=3,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        brute_force_keep_best_n=5,
+    )
+    assert_backtest(_fingerprint(result))
+
+
+def test_backtest_brighton_problem_p_median_greedy(brighton_problem, assert_backtest):
+    result = brighton_problem.solve(
+        p=3, objectives="p_median", search_strategy="greedy", show_progress=False
+    )
+    assert_backtest(_fingerprint(result))
+
+
+def test_backtest_brighton_problem_p_median_grasp(brighton_problem, assert_backtest):
+    result = brighton_problem.solve(
+        p=3,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=3,
+    )
+    assert_backtest(_fingerprint(result))
+
+
+def test_backtest_brighton_problem_p_center_brute_force(
+    brighton_problem, assert_backtest
+):
+    result = brighton_problem.solve(
+        p=2, objectives="p_center", search_strategy="brute-force", show_progress=False
+    )
+    assert_backtest(_fingerprint(result, cols=("max",)))
+
+
+def test_backtest_brighton_problem_mclp_brute_force(brighton_problem, assert_backtest):
+    result = brighton_problem.solve(
+        p=2,
+        objectives="mclp",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=20,
+    )
+    assert_backtest(
+        _fingerprint(result, cols=("proportion_within_coverage_threshold",))
+    )

--- a/tests/test_cost_weight_noop_direction.py
+++ b/tests/test_cost_weight_noop_direction.py
@@ -1,0 +1,219 @@
+"""
+Tests pinning that greedy and GRASP still sort/compare in the correct
+direction when cost weighting is REQUESTED but silently NO-OPS -- for
+both a maximising objective (mclp) and a minimising one (p_median).
+
+_apply_cost_weighting (utils.py) blends the primary ranking column with
+site cost onto a lower-is-better "composite_score" scale -- but only when
+it actually has usable cost data. It no-ops (returns the ORIGINAL
+ranking column, on the objective's own natural scale, unchanged) when
+e.g. every candidate's total_cost is NaN (add_sites(..., cost_col=...,
+allow_missing_cost=True) with no cost values ever provided).
+
+Three call sites -- _greedy's final sort, and _grasp's RCL construction
+and cost-weighted local search (mixins/site_solvers.py) -- assumed that
+"a positive cost weight was requested" implied "blending happened,
+therefore the score is lower-is-better", and hardcoded the
+ascending/minimising direction accordingly. That assumption breaks when
+_apply_cost_weighting no-ops: for mclp (higher-is-better coverage
+proportion), treating its raw score as lower-is-better inverted the
+search, so greedy/GRASP picked the WORST-coverage combinations as "best".
+
+Test design: rather than asserting the search reaches the GLOBAL optimum
+(brute-force's best), which greedy and a single GRASP construction
+attempt aren't guaranteed to reach regardless of this fix -- that's a
+separate, pre-existing property of those search strategies, not what
+this bug is about -- these tests assert the more precise invariant that
+actually follows from _apply_cost_weighting's documented no-op contract:
+a request that no-ops must behave IDENTICALLY to not requesting cost
+weighting at all, same random_seed included. That's exactly what would
+differ if the direction fallback were wrong, and it isn't dependent on
+whether the search strategy itself happens to find the global optimum.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import lokigi
+
+
+@pytest.fixture
+def problem_with_noop_cost():
+    """Same adversarial travel data as `five_site_problem` (the combination
+    with the best weighted_average is NOT the one with the best mclp
+    coverage), plus a cost_col registered with every site's cost missing
+    (allow_missing_cost=True) -- so weights={"cost": ...} passes solve()'s
+    validation (a cost_col IS configured) but _apply_cost_weighting no-ops
+    at evaluation time (every candidate's total_cost is NaN). Used for
+    both the mclp (maximising) and p_median (minimising) tests below."""
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "demand": [100, 100, 100, 100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_1", "Site_2", "Site_3", "Site_4", "Site_5"],
+            "lat": [51.1, 51.2, 51.3, 51.4, 51.5],
+            "long": [-0.1, -0.2, -0.3, -0.4, -0.5],
+            "build_cost": [np.nan] * 5,
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "Site_1": [38.0, 18.0, 10.0, 28.0],
+            "Site_2": [25.0, 40.0, 11.0, 31.0],
+            "Site_3": [24.0, 13.0, 29.0, 13.0],
+            "Site_4": [29.0, 16.0, 17.0, 16.0],
+            "Site_5": [17.0, 15.0, 17.0, 36.0],
+        }
+    )
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(
+        candidate_df,
+        candidate_id_col="site_id",
+        cost_col="build_cost",
+        allow_missing_cost=True,
+    )
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+def _assert_noop_cost_matches_no_cost(problem, solve_kwargs):
+    """Solve once with a cost weight that's requested but no-ops (NaN
+    costs), and once with cost omitted entirely -- same everything else,
+    including random_seed for GRASP. If the no-op direction fallback is
+    correct, these must produce the identical top solution."""
+    with_noop_cost = problem.solve(
+        weights={"demand": 0.5, "cost": 0.5}, **solve_kwargs
+    )
+    without_cost = problem.solve(weights={"demand": 1.0}, **solve_kwargs)
+
+    assert (
+        with_noop_cost.solution_df.iloc[0]["site_names"]
+        == without_cost.solution_df.iloc[0]["site_names"]
+    )
+    assert with_noop_cost.solution_df.iloc[0]["weighted_average"] == pytest.approx(
+        without_cost.solution_df.iloc[0]["weighted_average"]
+    )
+
+
+# --- mclp (maximising) ---
+
+
+def test_greedy_mclp_noop_cost_matches_no_cost_weight(problem_with_noop_cost):
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="mclp",
+            search_strategy="greedy",
+            show_progress=False,
+            threshold_for_coverage=15,
+        ),
+    )
+
+
+def test_grasp_construction_mclp_noop_cost_matches_no_cost_weight(
+    problem_with_noop_cost,
+):
+    """local_search_chance=0.0 isolates GRASP's construction/RCL phase --
+    a mismatch here is attributable solely to the RCL sort-direction fix,
+    since local search never runs."""
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="mclp",
+            search_strategy="grasp",
+            show_progress=False,
+            threshold_for_coverage=15,
+            grasp_num_solutions=1,
+            grasp_max_attempts=30,
+            grasp_local_search_chance=0.0,
+            random_seed=1,
+        ),
+    )
+
+
+def test_grasp_with_local_search_mclp_noop_cost_matches_no_cost_weight(
+    problem_with_noop_cost,
+):
+    """local_search_chance=1.0 forces the cost-weighted local-search swap
+    comparison to run every attempt -- if its direction were still wrong,
+    it could swap a matching-so-far solution away to a different one."""
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="mclp",
+            search_strategy="grasp",
+            show_progress=False,
+            threshold_for_coverage=15,
+            grasp_num_solutions=1,
+            grasp_max_attempts=30,
+            grasp_local_search_chance=1.0,
+            random_seed=1,
+        ),
+    )
+
+
+# --- p_median (minimising) ---
+#
+# For a minimising objective, the no-op fallback (`is_minimization`) and
+# the blended case (always "lower is better") agree, so this direction
+# was never actually wrong in practice -- these tests exist to confirm
+# that positively, rather than only inferring it from the mclp case above
+# and the fact the full suite doesn't regress.
+
+
+def test_greedy_p_median_noop_cost_matches_no_cost_weight(problem_with_noop_cost):
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="p_median",
+            search_strategy="greedy",
+            show_progress=False,
+        ),
+    )
+
+
+def test_grasp_construction_p_median_noop_cost_matches_no_cost_weight(
+    problem_with_noop_cost,
+):
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="p_median",
+            search_strategy="grasp",
+            show_progress=False,
+            grasp_num_solutions=1,
+            grasp_max_attempts=30,
+            grasp_local_search_chance=0.0,
+            random_seed=1,
+        ),
+    )
+
+
+def test_grasp_with_local_search_p_median_noop_cost_matches_no_cost_weight(
+    problem_with_noop_cost,
+):
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="p_median",
+            search_strategy="grasp",
+            show_progress=False,
+            grasp_num_solutions=1,
+            grasp_max_attempts=30,
+            grasp_local_search_chance=1.0,
+            random_seed=1,
+        ),
+    )

--- a/tests/test_cost_weight_noop_direction.py
+++ b/tests/test_cost_weight_noop_direction.py
@@ -10,14 +10,24 @@ ranking column, on the objective's own natural scale, unchanged) when
 e.g. every candidate's total_cost is NaN (add_sites(..., cost_col=...,
 allow_missing_cost=True) with no cost values ever provided).
 
-Three call sites -- _greedy's final sort, and _grasp's RCL construction
-and cost-weighted local search (mixins/site_solvers.py) -- assumed that
+Four call sites -- _greedy's final sort, _grasp's RCL construction and
+cost-weighted local search (mixins/site_solvers.py), and site.py's
+shared final cross-strategy sort (_solve_pmedian_pcenter_mclp_problem,
+which runs after brute-force/greedy/grasp all return) -- assumed that
 "a positive cost weight was requested" implied "blending happened,
 therefore the score is lower-is-better", and hardcoded the
 ascending/minimising direction accordingly. That assumption breaks when
 _apply_cost_weighting no-ops: for mclp (higher-is-better coverage
 proportion), treating its raw score as lower-is-better inverted the
-search, so greedy/GRASP picked the WORST-coverage combinations as "best".
+search, so greedy/GRASP/the final sort picked the WORST-coverage
+combinations as "best".
+
+The site.py final-sort instance is only visible when there's more than
+one candidate solution to actually sort -- a single-solution result
+(greedy, or GRASP with num_solutions=1) makes "sort direction" moot, so
+it stayed hidden behind the earlier per-solver tests until specifically
+tested with brute-force's full (unpruned) output and GRASP with
+num_solutions > 1.
 
 Test design: rather than asserting the search reaches the GLOBAL optimum
 (brute-force's best), which greedy and a single GRASP construction
@@ -214,6 +224,60 @@ def test_grasp_with_local_search_p_median_noop_cost_matches_no_cost_weight(
             grasp_num_solutions=1,
             grasp_max_attempts=30,
             grasp_local_search_chance=1.0,
+            random_seed=1,
+        ),
+    )
+
+
+# --- site.py's shared final cross-strategy sort ---
+#
+# This is a SEPARATE bug site from the three above: it runs once, after
+# brute-force/greedy/grasp all return, and re-sorts/ranks WHATEVER list of
+# solutions that strategy produced. It only matters when there's more than
+# one solution to sort -- greedy and single-solution GRASP calls (used
+# throughout the tests above) never exercise it, since sorting a 1-row
+# result is a no-op regardless of direction. Brute-force with no
+# brute_force_keep_best_n/worst_n (returns every combination) and GRASP
+# with grasp_num_solutions > 1 both genuinely exercise it.
+
+
+def test_brute_force_full_results_mclp_noop_cost_matches_no_cost_weight(
+    problem_with_noop_cost,
+):
+    """Brute-force with no keep_best_n/worst_n returns all 10
+    combinations -- enough for the final sort's direction to actually
+    matter."""
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="mclp",
+            search_strategy="brute-force",
+            show_progress=False,
+            threshold_for_coverage=15,
+        ),
+    )
+
+
+def test_grasp_multiple_solutions_mclp_noop_cost_matches_no_cost_weight(
+    problem_with_noop_cost,
+):
+    """grasp_num_solutions=3 (with local search enabled, the default
+    grasp_local_search_chance=0.8) gives the final sort multiple distinct
+    solutions to rank -- GRASP's own construction/local-search direction
+    is already proven identical between the noop-cost and no-cost calls
+    by the tests above, so any remaining mismatch here is attributable to
+    the final sort specifically."""
+    _assert_noop_cost_matches_no_cost(
+        problem_with_noop_cost,
+        dict(
+            p=2,
+            objectives="mclp",
+            search_strategy="grasp",
+            show_progress=False,
+            threshold_for_coverage=15,
+            grasp_num_solutions=3,
+            grasp_max_attempts=30,
             random_seed=1,
         ),
     )

--- a/tests/test_equity_metrics.py
+++ b/tests/test_equity_metrics.py
@@ -64,7 +64,7 @@ def test_gap_relative_weighted_zero_baseline_guard():
         equity_col="imd_decile",
         common_col="location_id",
         label="equity",
-        direction="higher_is_better",
+        disadvantaged_end="low",
     )
 
     result = problem.evaluate_single_solution_single_objective(
@@ -118,7 +118,7 @@ def test_zero_weight_band_falls_back_to_unweighted_mean():
         equity_col="imd_decile",
         common_col="location_id",
         label="equity",
-        direction="higher_is_better",
+        disadvantaged_end="low",
     )
 
     result = problem.evaluate_single_solution_single_objective(
@@ -161,7 +161,7 @@ def test_fewer_than_three_equity_bins_skips_tertile_calculation():
         equity_col="imd_decile",
         common_col="location_id",
         label="equity",
-        direction="higher_is_better",
+        disadvantaged_end="low",
     )
 
     result = problem.evaluate_single_solution_single_objective(

--- a/tests/test_equity_weighting_direction.py
+++ b/tests/test_equity_weighting_direction.py
@@ -1,23 +1,26 @@
 """
-Tests for the direction of equity weighting in solve()/EvaluatedCombination.
+Tests for the direction of equity weighting in solve()/EvaluatedCombination,
+and for add_equity_data()'s `disadvantaged_end` parameter.
 
 These pin the fix for an inversion bug in EvaluatedCombination's
-compound-weight blending (site_solutions.py): the mapping from
-`_equity_data_direction` to the row-weight direction was backwards, so
+compound-weight blending (site_solutions.py): the mapping from the equity
+direction metadata to the row-weight direction was backwards, so
 weights={"equity": ...} gave the MOST weight to the LEAST deprived regions
 -- the exact opposite of the feature's purpose ("put more importance on
 improving access in the most deprived areas").
 
-Equity weighting must up-weight worse-off regions under BOTH encodings:
+Part of that fix replaced the ambiguous direction vocabulary
+("higher_is_better"/"higher_is_worse" -- better for whom?) with
+`disadvantaged_end`, which names the thing the feature acts on: whichever
+end of the equity scale is disadvantaged is the end that gets the weight.
 
-- direction="higher_is_better" (e.g. DLUHC IMD deciles, 10 = least
-  deprived): LOW values are the deprived regions and must get the weight.
-- direction="higher_is_worse" (e.g. raw IMD scores, higher = more
-  deprived): HIGH values are the deprived regions and must get the weight.
+- disadvantaged_end="low" (e.g. DLUHC IMD deciles, 1 = most deprived):
+  LOW values are the deprived regions and must get the weight.
+- disadvantaged_end="high" (e.g. raw IMD scores, higher = more deprived):
+  HIGH values are the deprived regions and must get the weight.
 
-The same fix also aligned add_equity_data()'s signature default with its
-docstring ("higher_is_better") -- previously the signature said
-"higher_is_worse" while the docstring said "higher_is_better".
+The old `direction` argument remains as a deprecated alias
+("higher_is_better" -> "low", "higher_is_worse" -> "high").
 """
 
 import pandas as pd
@@ -102,10 +105,10 @@ def _solve_equity_weighted(problem):
 
 
 def test_decile_data_prioritises_most_deprived_region():
-    """IMD deciles (1 = most deprived) with the documented
-    direction="higher_is_better": the deprived LSOA must dominate the
-    weighting, so the best site is the one nearest to it."""
-    problem = _add_equity(_two_site_problem(), [1, 5, 10], direction="higher_is_better")
+    """IMD deciles (1 = most deprived) with disadvantaged_end="low": the
+    deprived LSOA must dominate the weighting, so the best site is the one
+    nearest to it."""
+    problem = _add_equity(_two_site_problem(), [1, 5, 10], disadvantaged_end="low")
     result = _solve_equity_weighted(problem)
 
     best = result.solution_df.iloc[0]
@@ -115,9 +118,9 @@ def test_decile_data_prioritises_most_deprived_region():
 
 def test_raw_score_data_prioritises_most_deprived_region():
     """Raw IMD-style scores (higher = more deprived) with
-    direction="higher_is_worse": high-score (deprived) regions must get
-    the weight, so the same site wins."""
-    problem = _add_equity(_two_site_problem(), [90, 50, 0], direction="higher_is_worse")
+    disadvantaged_end="high": high-score (deprived) regions must get the
+    weight, so the same site wins."""
+    problem = _add_equity(_two_site_problem(), [90, 50, 0], disadvantaged_end="high")
     result = _solve_equity_weighted(problem)
 
     best = result.solution_df.iloc[0]
@@ -131,10 +134,10 @@ def test_equivalent_decile_and_score_encodings_agree():
     """The two encodings of the same underlying deprivation ordering must
     produce identical weighted averages for every combination."""
     decile_problem = _add_equity(
-        _two_site_problem(), [1, 5, 10], direction="higher_is_better"
+        _two_site_problem(), [1, 5, 10], disadvantaged_end="low"
     )
     score_problem = _add_equity(
-        _two_site_problem(), [10, 6, 1], direction="higher_is_worse"
+        _two_site_problem(), [10, 6, 1], disadvantaged_end="high"
     )
 
     decile_result = _solve_equity_weighted(decile_problem)
@@ -160,7 +163,7 @@ def test_equivalent_decile_and_score_encodings_agree():
 def test_equity_weighted_ranking_orders_all_combinations_correctly():
     """Not just the winner: the full solution_df must rank the
     deprived-serving site above the affluent-serving one."""
-    problem = _add_equity(_two_site_problem(), [1, 5, 10], direction="higher_is_better")
+    problem = _add_equity(_two_site_problem(), [1, 5, 10], disadvantaged_end="low")
     result = _solve_equity_weighted(problem)
 
     ranked_sites = [names[0] for names in result.solution_df["site_names"]]
@@ -168,19 +171,77 @@ def test_equity_weighted_ranking_orders_all_combinations_correctly():
     assert result.solution_df.iloc[1]["weighted_average"] == pytest.approx(550 / 14)
 
 
-# --- default direction ---
+# --- default ---
 
 
-def test_default_direction_is_the_documented_decile_convention():
-    """add_equity_data()'s docstring documents the default as
-    "higher_is_better" (the DLUHC IMD decile convention); the signature
-    must match, so decile data with no explicit direction still
+def test_default_disadvantaged_end_is_low():
+    """The default matches the most common input (DLUHC IMD deciles,
+    1 = most deprived), so decile data with no explicit argument still
     prioritises the most deprived region."""
-    problem = _add_equity(_two_site_problem(), [1, 5, 10])  # direction omitted
+    problem = _add_equity(_two_site_problem(), [1, 5, 10])  # end omitted
     result = _solve_equity_weighted(problem)
 
     assert result.solution_df.iloc[0]["site_names"] == ["Site_NearDeprived"]
-    assert problem._equity_data_direction == "higher_is_better"
+    assert problem._equity_data_disadvantaged_end == "low"
+
+
+# --- deprecated `direction` alias ---
+
+
+@pytest.mark.parametrize(
+    "legacy_direction,expected_end",
+    [("higher_is_better", "low"), ("higher_is_worse", "high")],
+)
+def test_legacy_direction_maps_to_disadvantaged_end_and_warns(
+    legacy_direction, expected_end
+):
+    """The deprecated direction vocabulary must keep working, emit a
+    FutureWarning pointing at the replacement, and resolve to the
+    equivalent disadvantaged_end."""
+    problem = _two_site_problem()
+    with pytest.warns(FutureWarning, match="disadvantaged_end"):
+        _add_equity(problem, [1, 5, 10], direction=legacy_direction)
+
+    assert problem._equity_data_disadvantaged_end == expected_end
+
+
+def test_legacy_direction_produces_identical_results_to_new_spelling():
+    """direction="higher_is_better" and disadvantaged_end="low" must be
+    behaviourally indistinguishable end-to-end."""
+    new_problem = _add_equity(_two_site_problem(), [1, 5, 10], disadvantaged_end="low")
+    legacy_problem = _two_site_problem()
+    with pytest.warns(FutureWarning):
+        _add_equity(legacy_problem, [1, 5, 10], direction="higher_is_better")
+
+    new_result = _solve_equity_weighted(new_problem)
+    legacy_result = _solve_equity_weighted(legacy_problem)
+
+    assert list(new_result.solution_df["site_names"]) == list(
+        legacy_result.solution_df["site_names"]
+    )
+    assert list(new_result.solution_df["weighted_average"]) == pytest.approx(
+        list(legacy_result.solution_df["weighted_average"])
+    )
+
+
+def test_passing_both_direction_and_disadvantaged_end_raises():
+    with pytest.raises(ValueError, match="deprecated alias"):
+        _add_equity(
+            _two_site_problem(),
+            [1, 5, 10],
+            disadvantaged_end="low",
+            direction="higher_is_better",
+        )
+
+
+def test_invalid_disadvantaged_end_raises():
+    with pytest.raises(ValueError, match="'low' or 'high'"):
+        _add_equity(_two_site_problem(), [1, 5, 10], disadvantaged_end="lowest")
+
+
+def test_invalid_legacy_direction_raises():
+    with pytest.raises(ValueError, match="higher_is_better"):
+        _add_equity(_two_site_problem(), [1, 5, 10], direction="better")
 
 
 # --- blending and degenerate cases ---
@@ -205,7 +266,7 @@ def test_blended_demand_and_equity_weights_use_corrected_direction():
     problem.demand_data.loc[
         problem.demand_data["location_id"] == "LSOA_AFFLUENT", "demand"
     ] = 200
-    _add_equity(problem, [1, 5, 10], direction="higher_is_better")
+    _add_equity(problem, [1, 5, 10], disadvantaged_end="low")
 
     result = problem.solve(
         p=1,
@@ -230,7 +291,7 @@ def test_uniform_equity_values_give_equal_weights():
     """When every region has the same equity value there is nothing to
     normalise against; each region gets an equal (full) weight and the
     equity-weighted average collapses to the plain mean."""
-    problem = _add_equity(_two_site_problem(), [5, 5, 5], direction="higher_is_better")
+    problem = _add_equity(_two_site_problem(), [5, 5, 5], disadvantaged_end="low")
     result = _solve_equity_weighted(problem)
 
     for _, row in result.solution_df.iterrows():
@@ -245,7 +306,7 @@ def test_equity_weighting_beats_demand_weighting_at_serving_deprived_areas():
     problem.demand_data.loc[
         problem.demand_data["location_id"] == "LSOA_AFFLUENT", "demand"
     ] = 1000
-    _add_equity(problem, [1, 5, 10], direction="higher_is_better")
+    _add_equity(problem, [1, 5, 10], disadvantaged_end="low")
 
     demand_choice = problem.solve(
         p=1,

--- a/tests/test_equity_weighting_direction.py
+++ b/tests/test_equity_weighting_direction.py
@@ -1,0 +1,260 @@
+"""
+Tests for the direction of equity weighting in solve()/EvaluatedCombination.
+
+These pin the fix for an inversion bug in EvaluatedCombination's
+compound-weight blending (site_solutions.py): the mapping from
+`_equity_data_direction` to the row-weight direction was backwards, so
+weights={"equity": ...} gave the MOST weight to the LEAST deprived regions
+-- the exact opposite of the feature's purpose ("put more importance on
+improving access in the most deprived areas").
+
+Equity weighting must up-weight worse-off regions under BOTH encodings:
+
+- direction="higher_is_better" (e.g. DLUHC IMD deciles, 10 = least
+  deprived): LOW values are the deprived regions and must get the weight.
+- direction="higher_is_worse" (e.g. raw IMD scores, higher = more
+  deprived): HIGH values are the deprived regions and must get the weight.
+
+The same fix also aligned add_equity_data()'s signature default with its
+docstring ("higher_is_better") -- previously the signature said
+"higher_is_worse" while the docstring said "higher_is_better".
+"""
+
+import pandas as pd
+import pytest
+
+import lokigi
+
+
+def _two_site_problem():
+    """
+    A minimal, hand-checkable problem where the equity-optimal and
+    equity-pessimal sites are cleanly separated:
+
+    - LSOA_DEPRIVED / LSOA_MIDDLE / LSOA_AFFLUENT demand points.
+    - Site_NearDeprived is close to the deprived LSOA and far from the
+      affluent one; Site_NearAffluent is the mirror image.
+
+    With deciles [1, 5, 10], min-max normalisation gives [0, 4/9, 1], so a
+    correctly-inverted equity weighting yields row weights [1, 5/9, 0] and:
+
+    - Site_NearDeprived weighted_average = (5*1 + 20*5/9) / (14/9) = 145/14
+    - Site_NearAffluent weighted_average = (50*1 + 20*5/9) / (14/9) = 550/14
+
+    The inverted (buggy) weighting instead picks Site_NearAffluent.
+    """
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_DEPRIVED", "LSOA_MIDDLE", "LSOA_AFFLUENT"],
+            "demand": [100, 100, 100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_NearDeprived", "Site_NearAffluent"],
+            "lat": [51.1, 51.2],
+            "long": [-0.1, -0.2],
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_DEPRIVED", "LSOA_MIDDLE", "LSOA_AFFLUENT"],
+            "Site_NearDeprived": [5.0, 20.0, 50.0],
+            "Site_NearAffluent": [50.0, 20.0, 5.0],
+        }
+    )
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(candidate_df, candidate_id_col="site_id")
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+def _add_equity(problem, values, **kwargs):
+    equity_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_DEPRIVED", "LSOA_MIDDLE", "LSOA_AFFLUENT"],
+            "equity_value": values,
+        }
+    )
+    problem.add_equity_data(
+        equity_df,
+        equity_col="equity_value",
+        common_col="location_id",
+        label="equity",
+        verbose=False,
+        **kwargs,
+    )
+    return problem
+
+
+def _solve_equity_weighted(problem):
+    return problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"equity": 1.0},
+    )
+
+
+# --- core direction behaviour, both encodings ---
+
+
+def test_decile_data_prioritises_most_deprived_region():
+    """IMD deciles (1 = most deprived) with the documented
+    direction="higher_is_better": the deprived LSOA must dominate the
+    weighting, so the best site is the one nearest to it."""
+    problem = _add_equity(_two_site_problem(), [1, 5, 10], direction="higher_is_better")
+    result = _solve_equity_weighted(problem)
+
+    best = result.solution_df.iloc[0]
+    assert best["site_names"] == ["Site_NearDeprived"]
+    assert best["weighted_average"] == pytest.approx(145 / 14)
+
+
+def test_raw_score_data_prioritises_most_deprived_region():
+    """Raw IMD-style scores (higher = more deprived) with
+    direction="higher_is_worse": high-score (deprived) regions must get
+    the weight, so the same site wins."""
+    problem = _add_equity(_two_site_problem(), [90, 50, 0], direction="higher_is_worse")
+    result = _solve_equity_weighted(problem)
+
+    best = result.solution_df.iloc[0]
+    assert best["site_names"] == ["Site_NearDeprived"]
+    # scores [90, 50, 0] normalise to [1, 5/9, 0] directly (no inversion),
+    # giving exactly the same row weights as the decile test above.
+    assert best["weighted_average"] == pytest.approx(145 / 14)
+
+
+def test_equivalent_decile_and_score_encodings_agree():
+    """The two encodings of the same underlying deprivation ordering must
+    produce identical weighted averages for every combination."""
+    decile_problem = _add_equity(
+        _two_site_problem(), [1, 5, 10], direction="higher_is_better"
+    )
+    score_problem = _add_equity(
+        _two_site_problem(), [10, 6, 1], direction="higher_is_worse"
+    )
+
+    decile_result = _solve_equity_weighted(decile_problem)
+    score_result = _solve_equity_weighted(score_problem)
+
+    decile_scores = dict(
+        zip(
+            [names[0] for names in decile_result.solution_df["site_names"]],
+            decile_result.solution_df["weighted_average"],
+        )
+    )
+    score_scores = dict(
+        zip(
+            [names[0] for names in score_result.solution_df["site_names"]],
+            score_result.solution_df["weighted_average"],
+        )
+    )
+    assert decile_scores.keys() == score_scores.keys()
+    for site, value in decile_scores.items():
+        assert score_scores[site] == pytest.approx(value)
+
+
+def test_equity_weighted_ranking_orders_all_combinations_correctly():
+    """Not just the winner: the full solution_df must rank the
+    deprived-serving site above the affluent-serving one."""
+    problem = _add_equity(_two_site_problem(), [1, 5, 10], direction="higher_is_better")
+    result = _solve_equity_weighted(problem)
+
+    ranked_sites = [names[0] for names in result.solution_df["site_names"]]
+    assert ranked_sites == ["Site_NearDeprived", "Site_NearAffluent"]
+    assert result.solution_df.iloc[1]["weighted_average"] == pytest.approx(550 / 14)
+
+
+# --- default direction ---
+
+
+def test_default_direction_is_the_documented_decile_convention():
+    """add_equity_data()'s docstring documents the default as
+    "higher_is_better" (the DLUHC IMD decile convention); the signature
+    must match, so decile data with no explicit direction still
+    prioritises the most deprived region."""
+    problem = _add_equity(_two_site_problem(), [1, 5, 10])  # direction omitted
+    result = _solve_equity_weighted(problem)
+
+    assert result.solution_df.iloc[0]["site_names"] == ["Site_NearDeprived"]
+    assert problem._equity_data_direction == "higher_is_better"
+
+
+# --- blending and degenerate cases ---
+
+
+def test_blended_demand_and_equity_weights_use_corrected_direction():
+    """A 50/50 demand+equity blend must apply the corrected equity
+    direction inside the compound row weights. With demand
+    [100, 400, 200] -> norm [0, 1, 1/3] and equity deciles [1, 5, 10] ->
+    weights [1, 5/9, 0], the blend is 0.5*demand + 0.5*equity =
+    [1/2, 14/18, 1/6], giving:
+
+    - Site_NearDeprived = (5*1/2 + 20*14/18 + 50*1/6) / (26/18) = 475/26
+    - Site_NearAffluent = (50*1/2 + 20*14/18 + 5*1/6) / (26/18) = 745/26
+
+    (The inverted, buggy direction gives equity weights [0, 4/9, 1] and
+    would rank Site_NearAffluent first instead.)"""
+    problem = _two_site_problem()
+    problem.demand_data.loc[
+        problem.demand_data["location_id"] == "LSOA_MIDDLE", "demand"
+    ] = 400
+    problem.demand_data.loc[
+        problem.demand_data["location_id"] == "LSOA_AFFLUENT", "demand"
+    ] = 200
+    _add_equity(problem, [1, 5, 10], direction="higher_is_better")
+
+    result = problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"demand": 0.5, "equity": 0.5},
+    )
+
+    scores = dict(
+        zip(
+            [names[0] for names in result.solution_df["site_names"]],
+            result.solution_df["weighted_average"],
+        )
+    )
+    assert scores["Site_NearDeprived"] == pytest.approx(475 / 26)
+    assert scores["Site_NearAffluent"] == pytest.approx(745 / 26)
+    assert result.solution_df.iloc[0]["site_names"] == ["Site_NearDeprived"]
+
+
+def test_uniform_equity_values_give_equal_weights():
+    """When every region has the same equity value there is nothing to
+    normalise against; each region gets an equal (full) weight and the
+    equity-weighted average collapses to the plain mean."""
+    problem = _add_equity(_two_site_problem(), [5, 5, 5], direction="higher_is_better")
+    result = _solve_equity_weighted(problem)
+
+    for _, row in result.solution_df.iterrows():
+        assert row["weighted_average"] == pytest.approx(row["unweighted_average"])
+
+
+def test_equity_weighting_beats_demand_weighting_at_serving_deprived_areas():
+    """End-to-end sanity check of the feature's whole point: when demand
+    pulls toward the affluent LSOA, switching from demand weights to
+    equity weights must flip the chosen site toward the deprived LSOA."""
+    problem = _two_site_problem()
+    problem.demand_data.loc[
+        problem.demand_data["location_id"] == "LSOA_AFFLUENT", "demand"
+    ] = 1000
+    _add_equity(problem, [1, 5, 10], direction="higher_is_better")
+
+    demand_choice = problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"demand": 1.0},
+    ).solution_df.iloc[0]["site_names"]
+    equity_choice = _solve_equity_weighted(problem).solution_df.iloc[0]["site_names"]
+
+    assert demand_choice == ["Site_NearAffluent"]
+    assert equity_choice == ["Site_NearDeprived"]

--- a/tests/test_evaluate_site_indices_validation.py
+++ b/tests/test_evaluate_site_indices_validation.py
@@ -1,0 +1,105 @@
+"""
+Tests pinning stricter validation of `site_indices`/`site_names` in
+evaluate_single_solution_single_objective (site.py).
+
+Previously, resolving `site_indices` used `.isin()` against
+candidate_sites, which:
+
+- Silently DROPPED any index that doesn't exist -- the only check was
+  "is the resolved names list non-empty", which caught the all-invalid
+  case but let a PARTIALLY-invalid list (e.g. one real index plus one
+  nonexistent one) through, silently evaluating a smaller solution than
+  the caller asked for (no error, no warning).
+- Silently COLLAPSED duplicate indices to a single entry, for the same
+  reason -- each candidate site appears once in candidate_sites no
+  matter how many times its index is repeated in site_indices.
+
+Separately, the "exactly one of site_names/site_indices" mutual-
+exclusivity check used truthiness (`site_names and site_indices`)
+instead of `is not None`, so an explicitly-passed empty list ([]) was
+treated as "not provided" -- meaning site_names=[] silently bypassed
+both the "neither provided" and "both provided" checks.
+
+The fixed behaviour: any index in site_indices that doesn't exist in
+candidate_sites raises IndexError naming exactly which ones; duplicate
+indices raise ValueError; and an empty list for either parameter raises
+ValueError rather than silently slipping through.
+"""
+
+import pytest
+
+import lokigi
+
+
+def test_partially_invalid_site_indices_raises_instead_of_silently_shrinking(
+    loaded_problem,
+):
+    """The core bug: site_indices=[0, 999] (one real site, one that
+    doesn't exist) used to silently evaluate just site 0 -- a smaller
+    solution than requested, with no error."""
+    with pytest.raises(IndexError, match=r"\[999\]"):
+        loaded_problem.evaluate_single_solution_single_objective(
+            objective="p_median", site_indices=[0, 999]
+        )
+
+
+def test_entirely_invalid_site_indices_still_raises(loaded_problem):
+    """Regression: the case that already worked (every index invalid)
+    must keep working."""
+    with pytest.raises(IndexError, match=r"\[999\]"):
+        loaded_problem.evaluate_single_solution_single_objective(
+            objective="p_median", site_indices=[999]
+        )
+
+
+def test_duplicate_site_indices_raises_instead_of_silently_collapsing(loaded_problem):
+    """site_indices=[0, 0] used to silently resolve to a single site,
+    treating a 2-site request as if p=1."""
+    with pytest.raises(ValueError, match="duplicate"):
+        loaded_problem.evaluate_single_solution_single_objective(
+            objective="p_median", site_indices=[0, 0]
+        )
+
+
+def test_empty_site_indices_list_raises(loaded_problem):
+    with pytest.raises(ValueError, match="empty"):
+        loaded_problem.evaluate_single_solution_single_objective(
+            objective="p_median", site_indices=[]
+        )
+
+
+def test_empty_site_names_list_raises(loaded_problem):
+    """The empty-list gap applied to site_names too -- site_names=[]
+    previously bypassed the mutual-exclusivity check entirely (an empty
+    list is falsy, so `site_names and site_indices` never saw it as
+    "provided")."""
+    with pytest.raises(ValueError, match="empty"):
+        loaded_problem.evaluate_single_solution_single_objective(
+            objective="p_median", site_names=[]
+        )
+
+
+def test_valid_site_indices_still_work(loaded_problem):
+    result = loaded_problem.evaluate_single_solution_single_objective(
+        objective="p_median", site_indices=[0, 1]
+    )
+    assert sorted(result.site_names) == ["Site_A", "Site_B"]
+
+
+def test_valid_site_names_still_work(loaded_problem):
+    result = loaded_problem.evaluate_single_solution_single_objective(
+        objective="p_median", site_names=["Site_A"]
+    )
+    assert result.site_names == ["Site_A"]
+
+
+def test_neither_site_names_nor_site_indices_raises(loaded_problem):
+    with pytest.raises(ValueError, match="but not both"):
+        loaded_problem.evaluate_single_solution_single_objective(objective="p_median")
+
+
+def test_both_site_names_and_site_indices_raises(loaded_problem):
+    with pytest.raises(ValueError, match="but not both"):
+        loaded_problem.evaluate_single_solution_single_objective(
+            objective="p_median", site_names=["Site_A"], site_indices=[0]
+        )

--- a/tests/test_evaluated_combination_metrics.py
+++ b/tests/test_evaluated_combination_metrics.py
@@ -15,13 +15,16 @@ from lokigi.site_solutions import EvaluatedCombination
 class _StubSiteProblem:
     """Minimal duck-typed stand-in -- EvaluatedCombination only reads
     _demand_data_demand_col (always) and _equity_data_equity_col/
-    _equity_data_direction (only if equity_data was actually configured)."""
+    _equity_data_disadvantaged_end (only if equity_data was actually
+    configured)."""
 
-    def __init__(self, demand_col="demand", equity_col=None, equity_direction=None):
+    def __init__(
+        self, demand_col="demand", equity_col=None, equity_disadvantaged_end=None
+    ):
         self._demand_data_demand_col = demand_col
         if equity_col is not None:
             self._equity_data_equity_col = equity_col
-            self._equity_data_direction = equity_direction
+            self._equity_data_disadvantaged_end = equity_disadvantaged_end
 
 
 @pytest.fixture
@@ -94,7 +97,7 @@ def test_coverage_by_equity_group_is_a_dict_not_a_tuple():
     result = _build(
         df,
         site_problem=_StubSiteProblem(
-            equity_col="equity_band", equity_direction="higher_is_better"
+            equity_col="equity_band", equity_disadvantaged_end="low"
         ),
     )
 

--- a/tests/test_grasp_diversity_threshold.py
+++ b/tests/test_grasp_diversity_threshold.py
@@ -1,0 +1,144 @@
+"""
+Tests pinning the corrected min_sites_different -> Jaccard distance
+threshold formula in `_grasp` (mixins/site_solvers.py).
+
+`min_sites_different=m` promises that any two accepted solutions differ
+in at least m of their p site positions -- i.e. their intersection size k
+satisfies p - k >= m. For two same-size (p) sets with intersection k,
+Jaccard distance is 2(p-k) / (2p-k), NOT the plain fraction m/p the code
+used to compute. Solving for the distance at the boundary k = p - m (the
+most-similar pair that should still be ACCEPTED) gives the correct
+threshold: 2m / (p + m), which is strictly larger than the old m/p
+whenever m > 1 and p > m.
+
+The practical effect: for m=1 or m=2 the two formulas happen to agree
+at every achievable integer intersection size (verified below), but for
+m >= 3 with p large enough relative to m (e.g. p >= 6 at m=3), the old
+threshold was too small -- pairs differing in only m-1 sites (one site
+too similar) were wrongly accepted as "diverse enough".
+"""
+
+import pytest
+
+import lokigi
+from lokigi.utils import _too_similar_to_accepted
+
+
+# --- pure-function pin: the exact bug and fix, hand-computed ---
+
+
+def test_old_formula_wrongly_accepted_a_too_similar_pair_at_m3_p6():
+    """Sanity check pinning the bug itself (not the fix): with the old
+    threshold (m/p = 0.5), two p=6 solutions sharing 4 sites (differing
+    in only 2, one short of the required 3) were incorrectly treated as
+    diverse enough. If this stops holding, the old formula wasn't
+    actually buggy for this case and the fix test below proves nothing."""
+    accepted = {0, 1, 2, 3, 4, 5}
+    candidate_differs_by_2 = {0, 1, 2, 3, 6, 7}  # intersection=4, differs in 2
+
+    old_threshold = 3 / 6  # min_sites_different=3, p=6
+    assert (
+        _too_similar_to_accepted(candidate_differs_by_2, [accepted], old_threshold)
+        is False
+    )
+
+
+def test_corrected_formula_rejects_the_same_too_similar_pair():
+    accepted = {0, 1, 2, 3, 4, 5}
+    candidate_differs_by_2 = {0, 1, 2, 3, 6, 7}  # intersection=4, differs in 2
+
+    new_threshold = (2 * 3) / (6 + 3)  # 2m / (p + m)
+    assert (
+        _too_similar_to_accepted(candidate_differs_by_2, [accepted], new_threshold)
+        is True
+    )
+
+
+def test_corrected_formula_still_accepts_the_exact_boundary():
+    """A pair differing in exactly m=3 sites (the minimum the user asked
+    for) must still be accepted under the corrected threshold -- the fix
+    must not overshoot and start rejecting solutions that satisfy the
+    constraint."""
+    accepted = {0, 1, 2, 3, 4, 5}
+    candidate_differs_by_3 = {0, 1, 2, 6, 7, 8}  # intersection=3, differs in 3
+
+    new_threshold = (2 * 3) / (6 + 3)
+    assert (
+        _too_similar_to_accepted(candidate_differs_by_3, [accepted], new_threshold)
+        is False
+    )
+
+
+# --- m=1 and m=2 are unaffected: both formulas agree at every integer k ---
+#
+# (The exact k = p - m boundary distance is, by construction, equal to the
+# new threshold -- and it also happens to equal the old threshold's
+# decision outcome for m=1/m=2, as proven analytically in this file's
+# module docstring context. Asserting that exact-equality boundary here
+# would compare two independently-computed floats that can legitimately
+# differ by 1 ulp depending on arithmetic order (2/11 vs 1 - 9/11), so
+# these tests use points with clear margin instead of the knife-edge
+# boundary -- the boundary itself is pinned separately, once, for the m=3
+# bug case above, where the exact floats involved are already known to
+# agree.)
+
+
+@pytest.mark.parametrize("p", [2, 4, 6, 10])
+def test_m1_unaffected_by_the_formula_change(p):
+    """m=1 (reject only exact duplicates) behaves identically under old
+    and new formulas: duplicates are always rejected, and a solution
+    differing in every site is always accepted."""
+    old_threshold = 1 / p
+    new_threshold = (2 * 1) / (p + 1)
+    accepted = set(range(p))
+    duplicate = set(range(p))  # k=p, differs in 0 -- must always be rejected
+    completely_different = set(range(p, 2 * p))  # k=0, differs in p -- must be accepted
+
+    for threshold in (old_threshold, new_threshold):
+        assert _too_similar_to_accepted(duplicate, [accepted], threshold) is True
+        assert (
+            _too_similar_to_accepted(completely_different, [accepted], threshold)
+            is False
+        )
+
+
+# --- _grasp computes the corrected threshold internally ---
+
+
+@pytest.mark.parametrize(
+    "p,m",
+    [(2, 1), (4, 1), (4, 2), (5, 2), (5, 4)],
+)
+def test_grasp_computes_the_corrected_threshold_internally(
+    five_site_problem, monkeypatch, p, m
+):
+    """Spy on _too_similar_to_accepted to capture the min_jaccard_distance
+    _grasp actually computes and passes down, and assert it matches
+    2m / (p + m) rather than the old m / p. (five_site_problem has 5
+    candidate sites, so p is kept within that range; the behavioural
+    bug itself only manifests at larger p -- see the pure-function tests
+    above for that -- this just pins the formula _grasp evaluates.)"""
+    captured = []
+    import lokigi.mixins.site_solvers as site_solvers_module
+
+    original = site_solvers_module._too_similar_to_accepted
+
+    def spy(new_set, accepted_sets, min_jaccard_distance):
+        captured.append(min_jaccard_distance)
+        return original(new_set, accepted_sets, min_jaccard_distance)
+
+    monkeypatch.setattr(site_solvers_module, "_too_similar_to_accepted", spy)
+
+    five_site_problem._grasp(
+        p=p,
+        objectives="p_median",
+        weights={"demand": 1.0},
+        num_solutions=1,
+        max_attempts=1,
+        min_sites_different=m,
+        random_seed=0,
+    )
+
+    assert captured, "Expected at least one diversity check during _grasp"
+    expected = (2.0 * m) / (p + m)
+    assert all(threshold == pytest.approx(expected) for threshold in captured)

--- a/tests/test_incomplete_equity_data.py
+++ b/tests/test_incomplete_equity_data.py
@@ -1,0 +1,270 @@
+"""
+Tests pinning how solve()/evaluation handle equity data that does not cover
+every demand location.
+
+These pin the fix for a silent-corruption bug: the per-solution equity
+merge in evaluate_single_solution_single_objective (site.py) had no `how=`
+argument, so it defaulted to an INNER join and any demand location missing
+from the equity data was silently dropped from the entire evaluation --
+shrinking every metric (max, weighted averages, coverage) for every solve,
+even when equity wasn't being weighted, and quietly voiding the hybrid
+objectives' max-cutoff guarantee.
+
+The fixed behaviour:
+
+- The equity merge is a LEFT join: demand locations missing from the
+  equity data keep their travel/cost rows (with NaN equity values), so all
+  primary metrics are computed over the full demand set.
+- solve() checks equity coverage once up front: incomplete coverage is a
+  hard error when "equity" is in the weights dict (the row weights would
+  be NaN), and a warning otherwise (the locations are merely excluded from
+  equity-band breakdowns).
+- EvaluatedCombination refuses to build compound row weights from a column
+  containing NaN, instead of letting NaN propagate silently into every
+  score.
+"""
+
+import warnings
+
+import pandas as pd
+import pytest
+
+import lokigi
+
+
+def _problem_with_worst_point_missing_from_equity(include_equity=True):
+    """
+    Four demand points, two sites. LSOA_MISSING is absent from the equity
+    data and is also Site_A's worst-case (max) travel point:
+
+    - Site_A travel times: [38, 18, 10, 28] -> true max 38 (at LSOA_MISSING)
+    - Site_B travel times: [25, 29, 11, 28] -> true max 29 (at LSOA_2)
+
+    Correct behaviour: Site_B wins p_center (29 < 38).
+    The buggy inner join dropped LSOA_MISSING, making Site_A's max appear
+    to be 28 and flipping the winner to Site_A.
+    """
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_MISSING", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "demand": [100, 100, 100, 100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_A", "Site_B"],
+            "lat": [51.1, 51.2],
+            "long": [-0.1, -0.2],
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_MISSING", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "Site_A": [38.0, 18.0, 10.0, 28.0],
+            "Site_B": [25.0, 29.0, 11.0, 28.0],
+        }
+    )
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(candidate_df, candidate_id_col="site_id")
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+
+    if include_equity:
+        equity_df = pd.DataFrame(
+            {
+                "location_id": ["LSOA_2", "LSOA_3", "LSOA_4"],  # no LSOA_MISSING
+                "imd_decile": [1, 5, 10],
+            }
+        )
+        problem.add_equity_data(
+            equity_df,
+            equity_col="imd_decile",
+            common_col="location_id",
+            label="equity",
+            disadvantaged_end="low",
+            verbose=False,
+        )
+    return problem
+
+
+# --- demand points must never be dropped from the metrics ---
+
+
+def test_demand_points_missing_from_equity_still_count_in_metrics():
+    """The worst-case travel point being absent from the equity data must
+    not erase it: Site_A's max stays 38, and Site_B (true max 29) wins
+    p_center. The buggy inner join reported Site_A's max as 28 and flipped
+    the winner."""
+    problem = _problem_with_worst_point_missing_from_equity()
+    with pytest.warns(UserWarning, match="no matching row in the equity data"):
+        result = problem.solve(
+            p=1,
+            objectives="p_center",
+            search_strategy="brute-force",
+            show_progress=False,
+        )
+
+    best = result.solution_df.iloc[0]
+    assert best["site_names"] == ["Site_B"]
+    assert best["max"] == 29.0
+    assert sorted(result.solution_df["max"]) == [29.0, 38.0]
+
+
+def test_metrics_match_an_identical_problem_without_equity_data():
+    """Merely having (incomplete) equity data attached must not change any
+    primary metric relative to the same problem with no equity data."""
+    with_equity = _problem_with_worst_point_missing_from_equity(include_equity=True)
+    without_equity = _problem_with_worst_point_missing_from_equity(
+        include_equity=False
+    )
+
+    with pytest.warns(UserWarning, match="no matching row in the equity data"):
+        with_result = with_equity.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+        )
+    without_result = without_equity.solve(
+        p=1, objectives="p_median", search_strategy="brute-force", show_progress=False
+    )
+
+    for metric in ["weighted_average", "unweighted_average", "max"]:
+        with_scores = dict(
+            zip(
+                [names[0] for names in with_result.solution_df["site_names"]],
+                with_result.solution_df[metric],
+            )
+        )
+        without_scores = dict(
+            zip(
+                [names[0] for names in without_result.solution_df["site_names"]],
+                without_result.solution_df[metric],
+            )
+        )
+        assert with_scores == pytest.approx(without_scores)
+
+
+def test_hybrid_cutoff_guarantee_covers_all_demand_points():
+    """hybrid objectives promise every demand point sits within
+    max_value_cutoff. With a cutoff of 30, Site_A (true max 38, at the
+    LSOA missing from the equity data) must be filtered out -- the buggy
+    inner join hid that point and let Site_A through."""
+    problem = _problem_with_worst_point_missing_from_equity()
+    with pytest.warns(UserWarning, match="no matching row in the equity data"):
+        result = problem.solve(
+            p=1,
+            objectives="hybrid_p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            max_value_cutoff=30,
+        )
+
+    assert len(result.solution_df) == 1
+    assert result.solution_df.iloc[0]["site_names"] == ["Site_B"]
+
+
+# --- solve()'s upfront coverage check ---
+
+
+def test_solve_warns_when_equity_incomplete_but_not_weighted():
+    problem = _problem_with_worst_point_missing_from_equity()
+    with pytest.warns(UserWarning, match="1 of 4 demand"):
+        problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+        )
+
+
+def test_solve_raises_when_weighting_by_incomplete_equity():
+    """NaN equity values make equity row weights impossible, so asking to
+    weight by equity with incomplete coverage must fail fast and clearly,
+    before any solving starts."""
+    problem = _problem_with_worst_point_missing_from_equity()
+    with pytest.raises(ValueError, match="Cannot weight by equity"):
+        problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"equity": 1.0},
+        )
+
+
+def test_no_warning_when_equity_data_is_complete():
+    problem = _problem_with_worst_point_missing_from_equity(include_equity=False)
+    equity_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_MISSING", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "imd_decile": [3, 1, 5, 10],
+        }
+    )
+    problem.add_equity_data(
+        equity_df,
+        equity_col="imd_decile",
+        common_col="location_id",
+        label="equity",
+        disadvantaged_end="low",
+        verbose=False,
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"equity": 1.0},
+        )
+    equity_warnings = [w for w in caught if "equity data" in str(w.message)]
+    assert equity_warnings == []
+
+
+# --- the NaN guard on compound row weights ---
+
+
+def test_direct_evaluation_with_equity_weights_raises_on_missing_rows():
+    """evaluate_single_solution_single_objective doesn't pass through
+    solve()'s coverage check, so the NaN guard inside EvaluatedCombination
+    must catch incomplete equity coverage there instead of silently
+    producing NaN scores."""
+    problem = _problem_with_worst_point_missing_from_equity()
+    with pytest.raises(ValueError, match="missing values"):
+        problem.evaluate_single_solution_single_objective(
+            objective="p_median",
+            site_names=["Site_A"],
+            weights={"equity": 1.0},
+        )
+
+
+def test_nan_equity_value_with_equity_weight_raises():
+    """Complete ID coverage but a NaN in the equity column itself passes
+    solve()'s row-coverage check, so the NaN guard must catch it during
+    the first evaluation rather than letting NaN poison every score."""
+    problem = _problem_with_worst_point_missing_from_equity(include_equity=False)
+    equity_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_MISSING", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "imd_decile": [None, 1, 5, 10],
+        }
+    )
+    problem.add_equity_data(
+        equity_df,
+        equity_col="imd_decile",
+        common_col="location_id",
+        label="equity",
+        disadvantaged_end="low",
+        verbose=False,
+    )
+
+    with pytest.raises(ValueError, match="missing values"):
+        problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"equity": 1.0},
+        )

--- a/tests/test_max_value_cutoff_strategies.py
+++ b/tests/test_max_value_cutoff_strategies.py
@@ -1,0 +1,198 @@
+"""
+Tests pinning that max_value_cutoff (the hybrid objectives' "safety net")
+is honoured by EVERY search strategy, not just brute-force.
+
+These pin the fix for a silent-constraint-violation bug: solve() insisted
+hybrid objectives provide max_value_cutoff, but the dispatcher only
+forwarded it to `_brute_force` -- `_greedy` and `_grasp` didn't even have
+the parameter. Since the hybrid objectives' ranking columns equal their
+non-hybrid counterparts, hybrid_p_median + greedy/grasp silently behaved
+exactly like plain p_median: solutions violating the promised worst-case
+travel guarantee were returned, ranked normally, with no warning.
+
+The fixed behaviour:
+
+- Greedy applies the cutoff when choosing the final site (with fewer than
+  p sites the worst-case travel is usually still shrinking, so only the
+  final step is filtered), and raises a clear ValueError if no feasible
+  completion of its earlier choices exists.
+- GRASP rejects finished (post-local-search) solutions that violate the
+  cutoff, costing an attempt like a diversity reject.
+- A cutoff strict enough to rule out every combination now raises a clear
+  "No feasible solutions" ValueError from the dispatcher for any strategy,
+  instead of crashing with a cryptic KeyError on an empty DataFrame.
+"""
+
+import pandas as pd
+import pytest
+
+import lokigi
+
+
+@pytest.fixture
+def greedy_trap_problem():
+    """
+    Three sites, four equal-demand LSOAs, engineered so unconstrained
+    greedy walks into a cutoff violation that a different final site
+    would avoid:
+
+    - Site_A: [10, 20, 20, 30] -> weighted_average 20.00, max 30
+    - Site_B: [30,  6,  6, 40] -> weighted_average 20.50, max 40
+    - Site_C: [25, 25, 25, 12] -> weighted_average 21.75, max 25
+
+    Step 1 always picks Site_A (best weighted_average). At step 2:
+
+    - {A, B}: mins [10, 6, 6, 30] -> weighted_average 13.0, max 30
+    - {A, C}: mins [10, 20, 20, 12] -> weighted_average 15.5, max 20
+
+    Unconstrained greedy prefers {A, B} (13.0 < 15.5), which violates a
+    cutoff of 20 (LSOA_4 is left 30 away); {A, C} satisfies it. The
+    final-step filter must steer greedy to {A, C}.
+    """
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "demand": [100, 100, 100, 100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_A", "Site_B", "Site_C"],
+            "lat": [51.1, 51.2, 51.3],
+            "long": [-0.1, -0.2, -0.3],
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "Site_A": [10.0, 20.0, 20.0, 30.0],
+            "Site_B": [30.0, 6.0, 6.0, 40.0],
+            "Site_C": [25.0, 25.0, 25.0, 12.0],
+        }
+    )
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(candidate_df, candidate_id_col="site_id")
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+# --- greedy ---
+
+
+def test_unconstrained_greedy_walks_into_the_trap(greedy_trap_problem):
+    """Sanity check that the fixture discriminates: without a cutoff,
+    greedy picks {A, B} (max 30). If this stops holding, the cutoff tests
+    below no longer prove anything."""
+    result = greedy_trap_problem.solve(
+        p=2, objectives="p_median", search_strategy="greedy", show_progress=False
+    )
+    assert result.solution_df.iloc[0]["site_names"] == ["Site_A", "Site_B"]
+    assert result.solution_df.iloc[0]["max"] == 30.0
+
+
+@pytest.mark.parametrize("objective", ["hybrid_p_median", "hybrid_simple_p_median"])
+def test_greedy_final_step_respects_cutoff(greedy_trap_problem, objective):
+    """With max_value_cutoff=20, greedy must reject {A, B} (max 30) at the
+    final step and return {A, C} (max 20) instead of silently violating
+    the guarantee."""
+    result = greedy_trap_problem.solve(
+        p=2,
+        objectives=objective,
+        search_strategy="greedy",
+        show_progress=False,
+        max_value_cutoff=20,
+    )
+
+    best = result.solution_df.iloc[0]
+    assert best["site_names"] == ["Site_A", "Site_C"]
+    assert best["max"] == 20.0
+    assert all(result.solution_df["max"] <= 20)
+
+
+def test_greedy_cutoff_applies_when_p_is_one(greedy_trap_problem):
+    """With p=1 the first step IS the final step: Site_A (best
+    weighted_average, max 30) and Site_B (max 40) must be filtered out by
+    a cutoff of 25, leaving Site_C (max 25) as the only feasible single
+    site."""
+    result = greedy_trap_problem.solve(
+        p=1,
+        objectives="hybrid_p_median",
+        search_strategy="greedy",
+        show_progress=False,
+        max_value_cutoff=25,
+    )
+
+    best = result.solution_df.iloc[0]
+    assert best["site_names"] == ["Site_C"]
+    assert best["max"] == 25.0
+
+
+def test_greedy_raises_clearly_when_no_feasible_completion_exists(
+    greedy_trap_problem,
+):
+    """A cutoff of 15 rules out both completions of greedy's fixed first
+    pick ({A, B} max 30, {A, C} max 20), so greedy must fail loudly and
+    point at strategies that can still succeed."""
+    with pytest.raises(ValueError, match="max_value_cutoff=15"):
+        greedy_trap_problem.solve(
+            p=2,
+            objectives="hybrid_p_median",
+            search_strategy="greedy",
+            show_progress=False,
+            max_value_cutoff=15,
+        )
+
+
+# --- grasp ---
+
+
+def test_grasp_only_returns_solutions_within_cutoff(five_site_problem):
+    """On the adversarial five-site fixture, unconstrained GRASP's pool for
+    hybrid_p_median includes a solution with max 24; with a cutoff of 20,
+    every returned solution must satisfy it (only combinations with max 17
+    are feasible)."""
+    result = five_site_problem.solve(
+        p=2,
+        objectives="hybrid_p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        max_value_cutoff=20,
+        grasp_num_solutions=2,
+        grasp_max_attempts=50,
+        random_seed=42,
+    )
+
+    assert len(result.solution_df) >= 1
+    assert all(result.solution_df["max"] <= 20)
+
+
+def test_grasp_raises_clearly_when_cutoff_is_infeasible(five_site_problem):
+    """No two-site combination on the five-site fixture achieves max <= 5,
+    so GRASP must exhaust its attempts and surface a clear error rather
+    than crashing with a KeyError on an empty result set."""
+    with pytest.raises(ValueError, match="No feasible solutions"):
+        five_site_problem.solve(
+            p=2,
+            objectives="hybrid_p_median",
+            search_strategy="grasp",
+            show_progress=False,
+            max_value_cutoff=5,
+            grasp_num_solutions=2,
+        )
+
+
+# --- brute force: infeasible cutoff now errors clearly instead of crashing ---
+
+
+def test_brute_force_raises_clearly_when_cutoff_is_infeasible(five_site_problem):
+    """Previously a cutoff that filtered out every combination crashed
+    with KeyError('weighted_average') when ranking the empty DataFrame."""
+    with pytest.raises(ValueError, match="No feasible solutions"):
+        five_site_problem.solve(
+            p=2,
+            objectives="hybrid_p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            max_value_cutoff=5,
+        )

--- a/tests/test_mclp_demand_warning.py
+++ b/tests/test_mclp_demand_warning.py
@@ -1,0 +1,113 @@
+"""
+Tests pinning that the "no demand data" warning correctly exempts mclp,
+regardless of whether the caller passes objectives as a plain string or
+as a list.
+
+solve() resolves the caller's `objectives` argument (str or list of str)
+into a single `objective` string early on, but the missing-demand warning
+check further down compared the ORIGINAL `objectives` parameter to the
+literal string "mclp" -- so `objectives="mclp"` correctly matched and
+suppressed the warning, but `objectives=["mclp"]` never could (a list is
+never equal to a string), and the warning fired anyway for the one
+objective it was supposed to exempt.
+"""
+
+import warnings
+
+import pytest
+
+import lokigi
+
+
+@pytest.fixture
+def problem_without_demand():
+    """Sites and travel matrix, but demand deliberately not added -- the
+    condition that triggers solve()'s auto-equal-demand warning."""
+    import pandas as pd
+
+    candidate_df = pd.DataFrame(
+        {"site_id": ["Site_A", "Site_B"], "lat": [51.1, 51.2], "long": [-0.1, -0.2]}
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_1", "LSOA_2"],
+            "Site_A": [10.0, 20.0],
+            "Site_B": [20.0, 10.0],
+        }
+    )
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_sites(candidate_df, candidate_id_col="site_id")
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+def _demand_warnings(caught):
+    return [w for w in caught if "No demand data was provided" in str(w.message)]
+
+
+def test_mclp_as_a_list_is_still_exempt_from_the_demand_warning(
+    problem_without_demand,
+):
+    """The bug: objectives=["mclp"] used to still trigger the warning
+    because a list is never equal to the string "mclp"."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        problem_without_demand.solve(
+            p=1,
+            objectives=["mclp"],
+            search_strategy="brute-force",
+            show_progress=False,
+            threshold_for_coverage=15,
+        )
+
+    assert _demand_warnings(caught) == []
+
+
+def test_mclp_as_a_string_is_exempt_from_the_demand_warning(problem_without_demand):
+    """Sanity check / regression: the plain-string case already worked
+    before this fix and must keep working."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        problem_without_demand.solve(
+            p=1,
+            objectives="mclp",
+            search_strategy="brute-force",
+            show_progress=False,
+            threshold_for_coverage=15,
+        )
+
+    assert _demand_warnings(caught) == []
+
+
+def test_non_mclp_objectives_still_warn_about_missing_demand(problem_without_demand):
+    """Sanity check that the exemption is specific to mclp: a non-exempt
+    objective (as a plain string) must still warn -- if this stops
+    holding, the fixture no longer proves the exemption is selective."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        problem_without_demand.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+        )
+
+    assert len(_demand_warnings(caught)) == 1
+
+
+def test_non_mclp_objectives_as_a_list_still_warn_about_missing_demand(
+    problem_without_demand,
+):
+    """The multi-objective list path (only the first element is used,
+    with its own separate warning) must still warn about missing demand
+    when that first element isn't mclp."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        problem_without_demand.solve(
+            p=1,
+            objectives=["p_median"],
+            search_strategy="brute-force",
+            show_progress=False,
+        )
+
+    assert len(_demand_warnings(caught)) == 1

--- a/tests/test_required_sites.py
+++ b/tests/test_required_sites.py
@@ -26,7 +26,7 @@ import pytest
 import lokigi
 
 
-def _problem_with_terrible_required_site(mark_required=True):
+def _problem_with_terrible_required_site(mark_required=True, also_require=()):
     """
     Five sites, four equal-demand LSOAs. Site_Req is uniformly terrible
     (90 minutes from everywhere), so no search would ever pick it
@@ -40,6 +40,9 @@ def _problem_with_terrible_required_site(mark_required=True):
     Site_3 (20.75), Site_1 (23.5), Site_2 (26.75).
 
     Unconstrained, the p=2 optimum is {Site_1, Site_3} (15.0).
+
+    `also_require` marks additional site_ids as required, for exercising
+    the multiple-required-sites paths.
     """
     demand_df = pd.DataFrame(
         {
@@ -47,12 +50,18 @@ def _problem_with_terrible_required_site(mark_required=True):
             "demand": [100, 100, 100, 100],
         }
     )
+    site_ids = ["Site_1", "Site_2", "Site_3", "Site_4", "Site_Req"]
     candidate_df = pd.DataFrame(
         {
-            "site_id": ["Site_1", "Site_2", "Site_3", "Site_4", "Site_Req"],
+            "site_id": site_ids,
             "lat": [51.1, 51.2, 51.3, 51.4, 51.5],
             "long": [-0.1, -0.2, -0.3, -0.4, -0.5],
-            "must_build": ["no", "no", "no", "no", "yes" if mark_required else "no"],
+            "must_build": [
+                "yes"
+                if (site in also_require or (site == "Site_Req" and mark_required))
+                else "no"
+                for site in site_ids
+            ],
         }
     )
     travel_df = pd.DataFrame(
@@ -167,10 +176,9 @@ def test_grasp_raises_clearly_when_required_sites_exceed_p():
     """Two required sites cannot fit in a p=1 solution: GRASP must fail
     fast with a clear message rather than looping or silently dropping
     one of them."""
-    problem = _problem_with_terrible_required_site(mark_required=False)
-    problem.candidate_sites.loc[
-        problem.candidate_sites["site_id"].isin(["Site_1", "Site_2"]), "must_build"
-    ] = "yes"
+    problem = _problem_with_terrible_required_site(
+        mark_required=False, also_require=("Site_1", "Site_2")
+    )
 
     with pytest.raises(ValueError, match="required"):
         problem.solve(
@@ -205,3 +213,87 @@ def test_greedy_still_honours_a_single_required_site():
     best = result.solution_df.iloc[0]
     assert "Site_Req" in best["site_names"]
     assert sorted(best["site_names"]) == ["Site_4", "Site_Req"]
+
+
+# --- greedy with MULTIPLE required sites ---
+#
+# Greedy grows solutions one site at a time, but every size-i combination
+# is also filtered to contain ALL required sites -- so with two or more
+# required sites, the early steps (i < n_required) had no valid
+# combinations at all and greedy crashed with KeyError('weighted_average')
+# on the empty DataFrame. The fix seeds greedy's build with the required
+# sites and starts the loop at that size.
+
+
+def test_greedy_with_two_required_sites_returns_the_best_completion():
+    """With Site_Req and Site_2 required and p=3, the three possible
+    completions are hand-checkable (Site_Req's 90s never win a min, so
+    each scores the elementwise mins of Site_2 and the free site):
+
+      + Site_1: mins [25, 18, 10, 28] -> weighted_average 20.25
+      + Site_3: mins [24, 13, 11, 13] -> weighted_average 15.25
+      + Site_4: mins [25, 16, 11, 16] -> weighted_average 17.00
+
+    Greedy's single free choice sees all three completions at once, so it
+    must find the true constrained optimum here, matching brute-force."""
+    problem = _problem_with_terrible_required_site(also_require=("Site_2",))
+    greedy = problem.solve(
+        p=3, objectives="p_median", search_strategy="greedy", show_progress=False
+    )
+    brute_force = problem.solve(
+        p=3, objectives="p_median", search_strategy="brute-force", show_progress=False
+    )
+
+    best = greedy.solution_df.iloc[0]
+    assert sorted(best["site_names"]) == ["Site_2", "Site_3", "Site_Req"]
+    assert best["weighted_average"] == pytest.approx(15.25)
+    assert sorted(brute_force.solution_df.iloc[0]["site_names"]) == sorted(
+        best["site_names"]
+    )
+
+
+def test_greedy_when_p_equals_the_number_of_required_sites():
+    """With every slot taken by a required site there is nothing to
+    choose: greedy must return exactly the required set (elementwise mins
+    of Site_2 and Site_Req = Site_2's own times, weighted_average 26.75)
+    rather than crashing."""
+    problem = _problem_with_terrible_required_site(also_require=("Site_2",))
+    result = problem.solve(
+        p=2, objectives="p_median", search_strategy="greedy", show_progress=False
+    )
+
+    best = result.solution_df.iloc[0]
+    assert sorted(best["site_names"]) == ["Site_2", "Site_Req"]
+    assert best["weighted_average"] == pytest.approx(26.75)
+
+
+def test_greedy_raises_clearly_when_required_sites_exceed_p():
+    problem = _problem_with_terrible_required_site(also_require=("Site_2",))
+
+    with pytest.raises(ValueError, match="required"):
+        problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="greedy",
+            show_progress=False,
+        )
+
+
+def test_grasp_honours_two_required_sites():
+    """GRASP's construction seeding must handle any number of required
+    sites, not just one: every returned solution contains both."""
+    problem = _problem_with_terrible_required_site(also_require=("Site_2",))
+    result = problem.solve(
+        p=3,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=3,
+        grasp_max_attempts=50,
+        random_seed=42,
+    )
+
+    assert len(result.solution_df) >= 1
+    for site_names in result.solution_df["site_names"]:
+        assert "Site_Req" in site_names
+        assert "Site_2" in site_names

--- a/tests/test_required_sites.py
+++ b/tests/test_required_sites.py
@@ -1,0 +1,207 @@
+"""
+Tests pinning that required_sites_col (sites that MUST appear in every
+solution) is honoured by EVERY search strategy, not just brute-force.
+
+These pin the fix for a silent-constraint-violation bug: required sites
+were only enforced inside `_generate_all_combinations` (utils.py), which
+brute-force and greedy call -- but GRASP builds solutions incrementally
+from `range(total_n_sites)` and never calls it. GRASP therefore ignored
+required_sites_col completely: its randomised construction was free to
+omit required sites, and even when one was picked by chance, the 1-opt
+local search would happily swap it back out for anything better.
+
+The fixed behaviour:
+
+- GRASP seeds every construction with the required sites and only fills
+  the remaining p - n_required slots.
+- GRASP's local search never proposes swapping a required site out (in
+  both the plain and cost-weighted branches).
+- More required sites than p raises a clear ValueError up front.
+- The attempt budget's "total combinations" reflects only the free slots.
+"""
+
+import pandas as pd
+import pytest
+
+import lokigi
+
+
+def _problem_with_terrible_required_site(mark_required=True):
+    """
+    Five sites, four equal-demand LSOAs. Site_Req is uniformly terrible
+    (90 minutes from everywhere), so no search would ever pick it
+    voluntarily -- and local search would always want to swap it out.
+    That makes it the sharpest possible probe: Site_Req appears in a
+    solution if and only if the required-sites constraint is enforced.
+
+    With Site_Req required and p=2, only 4 combinations are feasible, and
+    each scores the partner site's own travel times (Site_Req's 90s never
+    win a min). Best partner by weighted_average: Site_4 (19.5), then
+    Site_3 (20.75), Site_1 (23.5), Site_2 (26.75).
+
+    Unconstrained, the p=2 optimum is {Site_1, Site_3} (15.0).
+    """
+    demand_df = pd.DataFrame(
+        {
+            "location_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "demand": [100, 100, 100, 100],
+        }
+    )
+    candidate_df = pd.DataFrame(
+        {
+            "site_id": ["Site_1", "Site_2", "Site_3", "Site_4", "Site_Req"],
+            "lat": [51.1, 51.2, 51.3, 51.4, 51.5],
+            "long": [-0.1, -0.2, -0.3, -0.4, -0.5],
+            "must_build": ["no", "no", "no", "no", "yes" if mark_required else "no"],
+        }
+    )
+    travel_df = pd.DataFrame(
+        {
+            "source_id": ["LSOA_1", "LSOA_2", "LSOA_3", "LSOA_4"],
+            "Site_1": [38.0, 18.0, 10.0, 28.0],
+            "Site_2": [25.0, 40.0, 11.0, 31.0],
+            "Site_3": [24.0, 13.0, 29.0, 13.0],
+            "Site_4": [29.0, 16.0, 17.0, 16.0],
+            "Site_Req": [90.0, 90.0, 90.0, 90.0],
+        }
+    )
+    problem = lokigi.site.SiteProblem(debug_mode=False)
+    problem.add_demand(demand_df, demand_col="demand", location_id_col="location_id")
+    problem.add_sites(
+        candidate_df, candidate_id_col="site_id", required_sites_col="must_build"
+    )
+    problem.add_travel_matrix(travel_df, source_col="source_id")
+    return problem
+
+
+# --- sanity: the fixture discriminates ---
+
+
+def test_unconstrained_grasp_omits_the_terrible_site():
+    """With no site marked required, GRASP must never return Site_Req --
+    if this stops holding, the constraint tests below no longer prove the
+    constraint (rather than luck) put Site_Req in the solutions."""
+    problem = _problem_with_terrible_required_site(mark_required=False)
+    result = problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=3,
+        random_seed=42,
+    )
+
+    for site_names in result.solution_df["site_names"]:
+        assert "Site_Req" not in site_names
+
+
+# --- GRASP must honour the required site ---
+
+
+def test_grasp_includes_required_site_in_every_solution():
+    problem = _problem_with_terrible_required_site()
+    result = problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=3,
+        random_seed=42,
+    )
+
+    assert len(result.solution_df) >= 1
+    for site_names in result.solution_df["site_names"]:
+        assert "Site_Req" in site_names
+
+
+def test_grasp_local_search_never_swaps_out_a_required_site():
+    """Site_Req is strictly worse than every alternative, so any 1-opt
+    swap replacing it improves the score -- if local search were allowed
+    to touch required sites it would ALWAYS remove Site_Req. Forcing
+    local search on every attempt makes this deterministic."""
+    problem = _problem_with_terrible_required_site()
+    result = problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=4,
+        grasp_max_attempts=50,
+        grasp_local_search_chance=1.0,
+        random_seed=42,
+    )
+
+    assert len(result.solution_df) >= 1
+    for site_names in result.solution_df["site_names"]:
+        assert "Site_Req" in site_names
+
+
+def test_grasp_finds_the_best_solution_containing_the_required_site():
+    """The constrained optimum is {Site_4, Site_Req} (weighted_average
+    19.5) -- GRASP's top-ranked solution must match brute-force's."""
+    problem = _problem_with_terrible_required_site()
+    brute_force = problem.solve(
+        p=2, objectives="p_median", search_strategy="brute-force", show_progress=False
+    )
+    grasp = problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="grasp",
+        show_progress=False,
+        grasp_num_solutions=3,
+        grasp_max_attempts=50,
+        random_seed=42,
+    )
+
+    assert sorted(brute_force.solution_df.iloc[0]["site_names"]) == [
+        "Site_4",
+        "Site_Req",
+    ]
+    assert sorted(grasp.solution_df.iloc[0]["site_names"]) == ["Site_4", "Site_Req"]
+    assert grasp.solution_df.iloc[0]["weighted_average"] == pytest.approx(
+        brute_force.solution_df.iloc[0]["weighted_average"]
+    )
+
+
+def test_grasp_raises_clearly_when_required_sites_exceed_p():
+    """Two required sites cannot fit in a p=1 solution: GRASP must fail
+    fast with a clear message rather than looping or silently dropping
+    one of them."""
+    problem = _problem_with_terrible_required_site(mark_required=False)
+    problem.candidate_sites.loc[
+        problem.candidate_sites["site_id"].isin(["Site_1", "Site_2"]), "must_build"
+    ] = "yes"
+
+    with pytest.raises(ValueError, match="required"):
+        problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="grasp",
+            show_progress=False,
+        )
+
+
+# --- regression: the shared helper must not change existing strategies ---
+
+
+def test_brute_force_still_only_returns_combinations_with_the_required_site():
+    problem = _problem_with_terrible_required_site()
+    result = problem.solve(
+        p=2, objectives="p_median", search_strategy="brute-force", show_progress=False
+    )
+
+    # 4 of the 10 possible pairs contain Site_Req
+    assert len(result.solution_df) == 4
+    for site_names in result.solution_df["site_names"]:
+        assert "Site_Req" in site_names
+
+
+def test_greedy_still_honours_a_single_required_site():
+    problem = _problem_with_terrible_required_site()
+    result = problem.solve(
+        p=2, objectives="p_median", search_strategy="greedy", show_progress=False
+    )
+
+    best = result.solution_df.iloc[0]
+    assert "Site_Req" in best["site_names"]
+    assert sorted(best["site_names"]) == ["Site_4", "Site_Req"]

--- a/tests/test_required_sites.py
+++ b/tests/test_required_sites.py
@@ -267,6 +267,23 @@ def test_greedy_when_p_equals_the_number_of_required_sites():
     assert best["weighted_average"] == pytest.approx(26.75)
 
 
+def test_brute_force_raises_clearly_when_required_sites_exceed_p():
+    """Two required sites cannot fit in a p=1 solution: brute-force must
+    fail fast with a clear message rather than falling through to the
+    generic, misleadingly-worded 'No feasible solutions' guard."""
+    problem = _problem_with_terrible_required_site(
+        mark_required=False, also_require=("Site_1", "Site_2")
+    )
+
+    with pytest.raises(ValueError, match="required"):
+        problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+        )
+
+
 def test_greedy_raises_clearly_when_required_sites_exceed_p():
     problem = _problem_with_terrible_required_site(also_require=("Site_2",))
 

--- a/tests/test_search_strategies.py
+++ b/tests/test_search_strategies.py
@@ -229,3 +229,109 @@ def test_brute_force_keep_best_n_handles_exact_score_ties(tied_score_problem):
     )
 
     assert len(result.solution_df) == 2
+
+
+# --- Brute force keep_best_n / keep_worst_n: mclp direction and coverage ---
+
+
+def test_keep_best_n_for_mclp_retains_the_highest_coverage_combinations(
+    five_site_problem,
+):
+    """Two stacked bugs previously broke keep_best_n for mclp: the keep-n
+    branch of `_brute_force` never passed threshold_for_coverage to its
+    evaluations (so every candidate scored coverage 0.0 and the heap
+    ranked noise), and the heaps assumed lower-is-better (so even with
+    real scores, keep_best_n retained the LOWEST-coverage combinations).
+    The kept set must match the top of a full brute-force run."""
+    full = five_site_problem.solve(
+        p=2,
+        objectives="mclp",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=15,
+    )
+    full_coverages = sorted(
+        full.solution_df["proportion_within_coverage_threshold"], reverse=True
+    )
+
+    kept = five_site_problem.solve(
+        p=2,
+        objectives="mclp",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=15,
+        brute_force_keep_best_n=3,
+    )
+    kept_coverages = sorted(
+        kept.solution_df["proportion_within_coverage_threshold"], reverse=True
+    )
+
+    assert len(kept.solution_df) == 3
+    assert kept_coverages == pytest.approx(full_coverages[:3])
+    # The overall best solution must survive the pruning and rank first
+    assert kept.solution_df.iloc[0][
+        "proportion_within_coverage_threshold"
+    ] == pytest.approx(full_coverages[0])
+    # ... and the real threshold must have been used, not silently dropped
+    assert (kept.solution_df["coverage_threshold"] == 15).all()
+
+
+def test_keep_worst_n_for_mclp_retains_the_lowest_coverage_combinations(
+    five_site_problem,
+):
+    full = five_site_problem.solve(
+        p=2,
+        objectives="mclp",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=15,
+    )
+    full_coverages = sorted(full.solution_df["proportion_within_coverage_threshold"])
+
+    kept = five_site_problem.solve(
+        p=2,
+        objectives="mclp",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=15,
+        brute_force_keep_worst_n=3,
+    )
+    kept_coverages = sorted(kept.solution_df["proportion_within_coverage_threshold"])
+
+    assert len(kept.solution_df) == 3
+    assert kept_coverages == pytest.approx(full_coverages[:3])
+
+
+def test_keep_best_n_reports_coverage_metrics_for_minimising_objectives(
+    five_site_problem,
+):
+    """threshold_for_coverage is a reporting metric for non-mclp
+    objectives, but the keep-n branch previously dropped it, silently
+    zeroing the coverage columns of whatever was returned. The kept rows'
+    coverage must match the full run's values for the same site sets."""
+    full = five_site_problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=15,
+    )
+    full_coverage_by_sites = {
+        tuple(row["site_names"]): row["proportion_within_coverage_threshold"]
+        for _, row in full.solution_df.iterrows()
+    }
+
+    kept = five_site_problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        threshold_for_coverage=15,
+        brute_force_keep_best_n=2,
+    )
+
+    assert (kept.solution_df["coverage_threshold"] == 15).all()
+    for _, row in kept.solution_df.iterrows():
+        assert row["proportion_within_coverage_threshold"] == pytest.approx(
+            full_coverage_by_sites[tuple(row["site_names"])]
+        )

--- a/tests/test_search_strategies.py
+++ b/tests/test_search_strategies.py
@@ -335,3 +335,361 @@ def test_keep_best_n_reports_coverage_metrics_for_minimising_objectives(
         assert row["proportion_within_coverage_threshold"] == pytest.approx(
             full_coverage_by_sites[tuple(row["site_names"])]
         )
+
+
+# --- Brute force keep_best_n / keep_worst_n with cost weighting active ---
+#
+# `_brute_force`'s keep_best_n/keep_worst_n heap prunes to N using the raw,
+# pre-cost ranking value one combination at a time. Cost weighting only
+# gets applied afterwards, over whatever tiny subset the heap let survive
+# -- so a combination that only looks good once cost is blended in, but has
+# a mediocre raw ranking, was silently discarded before cost was ever
+# considered. Whenever a positive "cost" weight is active, keep_best_n/
+# keep_worst_n must instead materialise every combination and blend cost in
+# over the full batch before pruning.
+
+
+def test_brute_force_keep_best_n_with_cost_weighting_retains_the_true_cost_weighted_best(
+    cost_weighted_pruning_problem,
+):
+    """Site_Cheap has the worst raw weighted_average (15.0, dead last of 4)
+    but becomes the true cost-weighted best once a heavy cost weight is
+    applied. keep_best_n=1 must still find it, not whatever the raw-ranking
+    heap would have kept."""
+    full = cost_weighted_pruning_problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"demand": 0.05, "cost": 0.95},
+    )
+    assert full.solution_df.iloc[0]["site_names"] == ["Site_Cheap"]
+
+    with pytest.warns(UserWarning, match="brute_force_keep_best_n"):
+        pruned = cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+            brute_force_keep_best_n=1,
+        )
+
+    assert pruned.solution_df.iloc[0]["site_names"] == ["Site_Cheap"]
+
+
+def test_brute_force_keep_worst_n_with_cost_weighting_retains_the_true_cost_weighted_worst(
+    cost_weighted_pruning_problem,
+):
+    """Site_Mid is the true cost-weighted worst: unlike Site_Fast1/Fast2, it
+    is bad on BOTH dimensions at once (a mediocre 12.0 raw travel time, on
+    top of the same 1000.0 build_cost) which, once blended
+    (composite_score = 0.05*primary_badness + 0.95*cost_badness), gives it
+    a worse composite_score (~0.984) than Fast1 (~0.949) or Fast2
+    (~0.954). keep_worst_n=1 must find Site_Mid, not whatever the
+    raw-ranking heap (which only sees Site_Mid's better-than-Cheap raw
+    travel time) would have kept."""
+    with pytest.warns(UserWarning, match="brute_force_keep_worst_n"):
+        pruned = cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+            brute_force_keep_worst_n=1,
+        )
+
+    assert pruned.solution_df.iloc[0]["site_names"] == ["Site_Mid"]
+
+
+def test_brute_force_keep_best_n_and_keep_worst_n_combined_with_cost_weighting(
+    cost_weighted_pruning_problem,
+):
+    """Both flags set at once should still return best + worst, correctly
+    cost-weighted, via the same code path (mixins/site_solvers.py's
+    `best_list + worst_list` / concatenated-DataFrame return contract):
+    Site_Cheap (best) and Site_Mid (worst, see the keep_worst_n test
+    above)."""
+    with pytest.warns(UserWarning):
+        result = cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+            brute_force_keep_best_n=1,
+            brute_force_keep_worst_n=1,
+        )
+
+    kept_site_names = {row["site_names"][0] for _, row in result.solution_df.iterrows()}
+    assert len(result.solution_df) == 2
+    assert kept_site_names == {"Site_Cheap", "Site_Mid"}
+
+
+def test_brute_force_cost_weighted_keep_best_n_matches_full_run_top_n(
+    cost_weighted_five_site_problem,
+):
+    """On a larger (10-combination) adversarial search space, a pruned
+    cost-weighted keep_best_n=N run must retain exactly the same top-N
+    combinations as a full, unpruned run -- identified by which sites were
+    picked, not by comparing composite_score values directly: solve()
+    redundantly re-applies cost weighting once more, over just the
+    returned subset, for final display ordering (see
+    `_solve_pmedian_pcenter_mclp_problem`), which renormalizes the score
+    scale without changing which combinations were selected."""
+    weights = {"demand": 0.3, "cost": 0.7}
+
+    full = cost_weighted_five_site_problem.solve(
+        p=2,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights=weights,
+    )
+    full_top_4_site_sets = {
+        frozenset(row["site_names"])
+        for _, row in full.solution_df.head(4).iterrows()
+    }
+
+    with pytest.warns(UserWarning, match="brute_force_keep_best_n"):
+        kept = cost_weighted_five_site_problem.solve(
+            p=2,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights=weights,
+            brute_force_keep_best_n=4,
+        )
+    kept_site_sets = {
+        frozenset(row["site_names"]) for _, row in kept.solution_df.iterrows()
+    }
+
+    assert len(kept.solution_df) == 4
+    assert kept_site_sets == full_top_4_site_sets
+
+
+def test_brute_force_cost_weighted_keep_best_n_respects_max_value_cutoff(
+    cost_weighted_five_site_problem,
+):
+    """max_value_cutoff filtering (infeasible combinations dropped during
+    collection) must still apply when cost weighting forces keep_best_n
+    into the full-materialization path."""
+    weights = {"demand": 0.3, "cost": 0.7}
+
+    full = cost_weighted_five_site_problem.solve(
+        p=2,
+        objectives="hybrid_p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights=weights,
+        max_value_cutoff=30,
+    )
+    assert (full.solution_df["max"] <= 30).all()
+
+    with pytest.warns(UserWarning, match="brute_force_keep_best_n"):
+        kept = cost_weighted_five_site_problem.solve(
+            p=2,
+            objectives="hybrid_p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights=weights,
+            max_value_cutoff=30,
+            brute_force_keep_best_n=2,
+        )
+
+    assert (kept.solution_df["max"] <= 30).all()
+    assert len(kept.solution_df) == 2
+
+
+def test_brute_force_cost_weighted_keep_best_n_handles_exact_score_ties(
+    tied_score_problem_with_cost,
+):
+    """Site_A and Site_B tie exactly on both weighted_average and
+    build_cost, so they also tie exactly on composite_score once cost is
+    blended in -- both scoring strictly worse than Site_C, so
+    keep_worst_n=2 must return exactly {Site_A, Site_B}. The pandas-based
+    (nsmallest/nlargest) cost-weighted path must handle this tie without
+    crashing, unlike the heap-based path's need for an explicit
+    tie-breaker."""
+    with pytest.warns(UserWarning, match="brute_force_keep_worst_n"):
+        result = tied_score_problem_with_cost.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+            brute_force_keep_worst_n=2,
+        )
+
+    assert len(result.solution_df) == 2
+    assert set(row["site_names"][0] for _, row in result.solution_df.iterrows()) == {
+        "Site_A",
+        "Site_B",
+    }
+
+
+# --- Brute force keep_best_n / keep_worst_n: cost-fallback warning presence ---
+#
+# The warning is meant to fire exactly when BOTH keep_best_n/keep_worst_n
+# AND a positive cost weight are active together (the combination that
+# forces `_brute_force` to give up keep_n's memory-saving benefit). It
+# must stay silent for every other combination: keep_n alone, cost
+# weighting alone, or a "cost" key present but weighted at 0.
+
+
+def _cost_fallback_warnings(caught):
+    return [
+        w
+        for w in caught
+        if "was requested together with a cost weight" in str(w.message)
+    ]
+
+
+def test_warns_when_keep_best_n_and_cost_weighting_are_both_active(
+    cost_weighted_pruning_problem,
+):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+            brute_force_keep_best_n=1,
+        )
+
+    assert len(_cost_fallback_warnings(caught)) == 1
+
+
+def test_warns_when_keep_worst_n_and_cost_weighting_are_both_active(
+    cost_weighted_pruning_problem,
+):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+            brute_force_keep_worst_n=1,
+        )
+
+    assert len(_cost_fallback_warnings(caught)) == 1
+
+
+def test_warns_exactly_once_when_keep_best_n_and_keep_worst_n_are_both_active_with_cost_weighting(
+    cost_weighted_pruning_problem,
+):
+    """Both pruning flags set at once must still only warn once -- the
+    warning is about the fallback being triggered for this call, not one
+    per flag."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+            brute_force_keep_best_n=1,
+            brute_force_keep_worst_n=1,
+        )
+
+    assert len(_cost_fallback_warnings(caught)) == 1
+
+
+def test_no_cost_fallback_warning_when_keep_best_n_is_used_without_cost_weighting(
+    five_site_problem,
+):
+    """keep_best_n alone (no weights at all) must keep using the
+    memory-efficient streaming heap, silently -- the fallback and its
+    warning are specific to cost weighting being active."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        five_site_problem.solve(
+            p=2,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            brute_force_keep_best_n=3,
+        )
+
+    assert _cost_fallback_warnings(caught) == []
+
+
+def test_no_cost_fallback_warning_when_keep_worst_n_is_used_without_cost_weighting(
+    five_site_problem,
+):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        five_site_problem.solve(
+            p=2,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            brute_force_keep_worst_n=3,
+        )
+
+    assert _cost_fallback_warnings(caught) == []
+
+
+def test_no_cost_fallback_warning_when_keep_n_is_used_with_a_demand_only_weight(
+    cost_weighted_pruning_problem,
+):
+    """A weights dict that omits "cost" entirely (even though the problem
+    has a cost_col configured) must not trigger the fallback -- only an
+    actual positive "cost" weight should."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 1.0},
+            brute_force_keep_best_n=1,
+        )
+
+    assert _cost_fallback_warnings(caught) == []
+
+
+def test_no_cost_fallback_warning_when_cost_weight_is_zero(
+    cost_weighted_pruning_problem,
+):
+    """weights={"cost": 0} is present but not "positive" -- the same
+    `weights.get("cost", 0) > 0` check used everywhere else in this
+    codebase for "is cost weighting actually active" must treat it as
+    inactive, leaving keep_best_n on the cheap streaming path."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 1.0, "cost": 0},
+            brute_force_keep_best_n=1,
+        )
+
+    assert _cost_fallback_warnings(caught) == []
+
+
+def test_no_cost_fallback_warning_when_cost_weighting_is_used_without_keep_n(
+    cost_weighted_pruning_problem,
+):
+    """Cost weighting alone (no keep_best_n/keep_worst_n at all) already
+    materialises every combination -- there is nothing to fall back from,
+    so no warning should fire."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cost_weighted_pruning_problem.solve(
+            p=1,
+            objectives="p_median",
+            search_strategy="brute-force",
+            show_progress=False,
+            weights={"demand": 0.05, "cost": 0.95},
+        )
+
+    assert _cost_fallback_warnings(caught) == []

--- a/tests/test_solve_rejects_unknown_kwargs.py
+++ b/tests/test_solve_rejects_unknown_kwargs.py
@@ -1,0 +1,85 @@
+"""
+Tests pinning that solve() rejects unrecognised keyword arguments instead
+of silently swallowing them.
+
+solve()'s signature used to end with a bare `**kwargs` that was never
+read or forwarded anywhere -- dead code that existed only to catch
+anything not explicitly named. Its docstring even claimed "Additional
+arguments passed to the internal solver", which was false: nothing was
+ever passed anywhere. The practical effect was that any misspelled
+keyword (e.g. `serach_strategy` instead of `search_strategy`, or
+`treshold_for_coverage` instead of `threshold_for_coverage`) was silently
+absorbed and ignored, and solve() ran with whatever default that
+parameter has -- most dangerously, a misspelled `search_strategy` or
+`max_value_cutoff` would silently produce a DIFFERENT solution than the
+caller asked for, with no error or warning pointing at the typo.
+
+Removing `**kwargs` lets Python's own machinery raise a clear TypeError
+(with a "Did you mean...?" suggestion on modern Python) for any unknown
+keyword.
+"""
+
+import pytest
+
+import lokigi
+
+
+def test_solve_raises_on_a_misspelled_search_strategy(loaded_problem):
+    """The exact bug that motivated this fix: a typo'd search_strategy
+    used to be silently ignored, falling back to the default
+    'brute-force' instead of erroring."""
+    with pytest.raises(TypeError, match="serach_strategy"):
+        loaded_problem.solve(
+            p=1,
+            objectives="p_median",
+            serach_strategy="grasp",
+            show_progress=False,
+        )
+
+
+def test_solve_raises_on_a_misspelled_threshold_for_coverage(loaded_problem):
+    with pytest.raises(TypeError, match="treshold_for_coverage"):
+        loaded_problem.solve(
+            p=1,
+            objectives="mclp",
+            treshold_for_coverage=15,
+            show_progress=False,
+        )
+
+
+def test_solve_raises_on_a_completely_unknown_keyword(loaded_problem):
+    with pytest.raises(TypeError, match="not_a_real_parameter"):
+        loaded_problem.solve(
+            p=1,
+            objectives="p_median",
+            not_a_real_parameter=True,
+            show_progress=False,
+        )
+
+
+def test_solve_still_accepts_every_documented_keyword(loaded_problem_with_cost):
+    """Sanity check that removing **kwargs didn't accidentally break any
+    real, documented parameter -- every one of them should still be
+    accepted together without raising."""
+    result = loaded_problem_with_cost.solve(
+        p=1,
+        objectives="p_median",
+        weights={"demand": 0.5, "cost": 0.5},
+        capacitated=False,
+        search_strategy="brute-force",
+        brute_force_ignore_limit=False,
+        show_progress=False,
+        brute_force_keep_best_n=None,
+        brute_force_keep_worst_n=None,
+        max_value_cutoff=None,
+        threshold_for_coverage=None,
+        grasp_num_solutions=5,
+        grasp_alpha=0.2,
+        grasp_max_attempts="default",
+        grasp_min_sites_different=1,
+        grasp_local_search_chance=0.8,
+        grasp_max_swap_count_local_search=10,
+        random_seed=42,
+    )
+
+    assert len(result.solution_df) >= 1

--- a/tests/test_weight_key_case_sensitivity.py
+++ b/tests/test_weight_key_case_sensitivity.py
@@ -1,0 +1,201 @@
+"""
+Tests pinning that "demand" and "equity" weight keys are handled
+case-insensitively end-to-end, matching the case-insensitive validation
+solve() already performs.
+
+These pin the fix for a silent-crash bug: solve()'s missing-key check
+(site.py) validated weight keys case-insensitively ("Demand" was accepted
+as a valid reference to the demand column), but the actual per-row
+weighting logic in EvaluatedCombination (site_solutions.py) compared
+labels with exact-case `==` in one place (col_name resolution) while using
+`.lower()` a few lines later in the same function (direction resolution).
+A key like "Demand" therefore passed validation, then silently matched no
+real column: the row-level weight array stayed all zeros, and
+`np.average(..., weights=compound_weights)` crashed with
+`ZeroDivisionError: Weights sum to zero` -- a confusing error pointing
+nowhere near the actual typo-adjacent cause.
+
+`evaluate_single_solution_single_objective` never goes through solve()'s
+validation at all, so the fix lives in EvaluatedCombination itself (the
+root cause), with solve()'s own weight normalisation also canonicalising
+case for defence in depth.
+
+Additional-data labels are deliberately NOT case-normalised: they are
+user-defined exact strings registered via add_additional_data(label=...),
+not built-in keywords, so "CO2" continuing to mean something different
+from "co2" is correct, matching-string behaviour, not a bug.
+"""
+
+import pytest
+
+import lokigi
+
+
+# --- solve(): case must not affect the result ---
+
+
+def test_solve_with_uppercase_demand_weight_key_matches_lowercase(loaded_problem):
+    lower = loaded_problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"demand": 1.0},
+    )
+    upper = loaded_problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"Demand": 1.0},
+    )
+
+    assert upper.solution_df.iloc[0]["weighted_average"] == pytest.approx(
+        lower.solution_df.iloc[0]["weighted_average"]
+    )
+
+
+def test_solve_with_uppercase_demand_key_matches_the_default_weights(loaded_problem):
+    """A single {"Demand": 1.0} weight should take the same legacy
+    fast-path as weights=None / the implicit default -- not just avoid
+    crashing, but produce an identical result."""
+    default = loaded_problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+    )
+    uppercase_demand = loaded_problem.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"Demand": 1.0},
+    )
+
+    assert uppercase_demand.solution_df.iloc[0][
+        "weighted_average"
+    ] == pytest.approx(default.solution_df.iloc[0]["weighted_average"])
+
+
+def test_solve_with_uppercase_equity_weight_key_matches_lowercase(
+    loaded_problem_with_equity,
+):
+    lower = loaded_problem_with_equity.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"equity": 1.0},
+    )
+    upper = loaded_problem_with_equity.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"Equity": 1.0},
+    )
+
+    assert upper.solution_df.iloc[0]["weighted_average"] == pytest.approx(
+        lower.solution_df.iloc[0]["weighted_average"]
+    )
+
+
+def test_solve_with_mixed_case_blended_weights_matches_lowercase(
+    loaded_problem_with_equity,
+):
+    lower = loaded_problem_with_equity.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"demand": 0.5, "equity": 0.5},
+    )
+    mixed_case = loaded_problem_with_equity.solve(
+        p=1,
+        objectives="p_median",
+        search_strategy="brute-force",
+        show_progress=False,
+        weights={"Demand": 0.5, "EQUITY": 0.5},
+    )
+
+    assert mixed_case.solution_df.iloc[0]["weighted_average"] == pytest.approx(
+        lower.solution_df.iloc[0]["weighted_average"]
+    )
+
+
+# --- direct evaluate_single_solution_single_objective(): bypasses solve() entirely ---
+
+
+def test_direct_evaluation_with_uppercase_demand_weight_key(loaded_problem):
+    """evaluate_single_solution_single_objective doesn't pass through
+    solve()'s validation/normalisation, so the fix must live in
+    EvaluatedCombination itself, not just solve()."""
+    lower = loaded_problem.evaluate_single_solution_single_objective(
+        objective="p_median", site_names=["Site_A"], weights={"demand": 1.0}
+    ).return_solution_metrics()
+    upper = loaded_problem.evaluate_single_solution_single_objective(
+        objective="p_median", site_names=["Site_A"], weights={"Demand": 1.0}
+    ).return_solution_metrics()
+
+    assert upper["weighted_average"] == pytest.approx(lower["weighted_average"])
+
+
+def test_direct_evaluation_with_uppercase_equity_weight_key(
+    loaded_problem_with_equity,
+):
+    lower = loaded_problem_with_equity.evaluate_single_solution_single_objective(
+        objective="p_median", site_names=["Site_A"], weights={"equity": 1.0}
+    ).return_solution_metrics()
+    upper = loaded_problem_with_equity.evaluate_single_solution_single_objective(
+        objective="p_median", site_names=["Site_A"], weights={"Equity": 1.0}
+    ).return_solution_metrics()
+
+    assert upper["weighted_average"] == pytest.approx(lower["weighted_average"])
+
+
+# --- additional-data labels remain case-sensitive on purpose ---
+
+
+def test_additional_data_label_case_is_still_significant(
+    loaded_problem_with_additional_data,
+):
+    """"co2" was registered via add_additional_data(label="co2"); unlike
+    the built-in "demand"/"equity" keywords, a differently-cased weight
+    key here is a genuine mismatch, not a formatting quirk -- it must
+    still raise, not be silently accepted."""
+    with pytest.raises(ValueError, match="does not correspond to demand"):
+        loaded_problem_with_additional_data.evaluate_single_solution_single_objective(
+            objective="p_median", site_names=["Site_A"], weights={"CO2": 1.0}
+        )
+
+
+def test_additional_data_label_lowercase_still_works(
+    loaded_problem_with_additional_data,
+):
+    """Sanity check that the fixture's registered label still resolves
+    correctly, so the case-sensitivity assertion above is meaningful
+    rather than masking an unrelated failure."""
+    result = loaded_problem_with_additional_data.evaluate_single_solution_single_objective(
+        objective="p_median", site_names=["Site_A"], weights={"co2": 1.0}
+    ).return_solution_metrics()
+
+    assert result["weighted_average"] == pytest.approx(
+        result["weighted_average"]
+    )  # finite, comparable number
+
+
+# --- adjacent bug found while fixing the above: an unrecognised weight
+# key (not a case mismatch -- a genuine typo, with no additional data
+# registered at all) must raise the intended "does not correspond to..."
+# error rather than being silently skipped and crashing later with
+# ZeroDivisionError. The direction-resolution/error-raising logic used to
+# live INSIDE the `if col_name in columns:` check, so a label whose
+# col_name was never a real column skipped straight past it. ---
+
+
+def test_unrecognised_weight_key_raises_clearly_instead_of_crashing(loaded_problem):
+    with pytest.raises(ValueError, match="does not correspond to demand"):
+        loaded_problem.evaluate_single_solution_single_objective(
+            objective="p_median", site_names=["Site_A"], weights={"populaton": 1.0}
+        )


### PR DESCRIPTION
This PR was largely undertaken with the aid of Claude Fable 5 and Claude Sonnet 5. Code underwent human review before incorporation.

# Bugfix pass across equity weighting, solvers, and evaluation

A batch of correctness fixes found while exercising lokigi against real usage, each pinned with a regression test proving it catches the bug (verified by reverting the fix and watching the new test fail). No public API removed; a few call sites gain new validation/errors where they previously failed silently.

## Equity weighting

- **Equity weighting was inverted** ([8d8ae08](../../commit/8d8ae08)): `weights={"equity": ...}` gave the *most* weight to the *least* deprived regions, under both documented direction encodings — the opposite of the feature's purpose. Fixed by correcting the direction→weight mapping and negating before normalisation (also fixes a latent zero-weight crash when all values tie). `add_equity_data()`'s direction default now matches its docstring.
- **Renamed `direction` → `disadvantaged_end`** ([bb957c5](../../commit/bb957c5)): the old `higher_is_better`/`higher_is_worse` vocabulary was ambiguous (better *for the region* vs. better *for weighting*) and was a root cause of the inversion above. `direction` is kept as a deprecated alias with a `FutureWarning`; passing both raises.
- **Incomplete equity data silently corrupted every metric** ([18341b8](../../commit/18341b8)): the equity merge was an inner join, so any demand point missing from equity data vanished from *all* metrics (max, weighted/unweighted averages, coverage), even when equity wasn't being weighted. Now a left join keeps every demand row (NaN equity where missing), `solve()` fails fast when `"equity"` is weighted over incomplete data, and `EvaluatedCombination` refuses to build weights from any NaN-containing column (also catches the same latent bug for `additional_data` weights).

## Search strategies (greedy / GRASP / brute-force)

- **`max_value_cutoff` ignored by greedy/GRASP** ([b35c86b](../../commit/b35c86b)): hybrid objectives require a worst-case travel cutoff, but only brute-force enforced it — greedy and GRASP silently returned solutions violating the guarantee. Both now enforce it (greedy at the final step, GRASP by rejecting non-conforming finished solutions), with a clear infeasibility error when nothing qualifies.
- **`required_sites_col` ignored by GRASP** ([a8e48fe](../../commit/a8e48fe)): GRASP builds solutions incrementally and never went through the combination-filtering path that enforces required sites, so a "required" site could be dropped by construction or swapped out by local search. Now seeded and swap-protected.
- **Greedy crashed with 2+ required sites** ([14387c3](../../commit/14387c3)): early growth steps had no valid combinations once more than one site was required, causing a `KeyError` on an empty result set. Greedy now seeds its build with the required sites.
- **`keep_best_n`/`keep_worst_n` broken for mclp** ([8806ce9](../../commit/8806ce9)): the keep-n branch never passed the coverage threshold (all coverage scored 0.0, retention was arbitrary) and assumed lower-is-better, so `keep_best_n` actually retained the *worst*-coverage combinations for mclp. Both fixed.
- **Cost-weight no-op inverted mclp's search** ([065df93](../../commit/065df93), [96465a6](../../commit/96465a6)): four call sites (greedy's final sort, GRASP's RCL construction and swap comparison, and the shared final sort in `site.py`) assumed a requested cost weight meant blending happened and hardcoded a lower-is-better sort. When cost blending silently no-ops (e.g. all-NaN cost data), this inverted mclp's search, returning the worst combination as "best". Now detects whether blending actually occurred and falls back to the objective's natural direction.
- **`min_sites_different` Jaccard threshold was wrong** ([2255d01](../../commit/2255d01)): GRASP's diversity threshold used the plain fraction `m/p` instead of the correct Jaccard-distance boundary `2m/(p+m)`, wrongly accepting solutions as "diverse enough" when they differed in one site fewer than requested (for `m >= 3` with `p` large enough).
- **`keep_best_n`/`keep_worst_n` pruned before cost was blended in** ([c768a09](../../commit/c768a09)): brute-force's streaming heap pruned to N using the raw ranking before cost weighting was applied afterward, so a combination with mediocre raw ranking but low cost never got the chance to prove it was the true cost-weighted best. Falls back to materialising the full batch and blending once when a positive cost weight is active (with a `UserWarning`).
- **Clear error when required sites exceed `p`** ([bd23438](../../commit/bd23438)): brute-force now raises the same explicit error greedy/GRASP already had, instead of falling through to a misleading "no feasible solutions" message.

## `solve()` / evaluation robustness

- **Unknown keyword arguments silently swallowed** ([18a4161](../../commit/18a4161)): a dead `**kwargs` on `solve()` absorbed typos like `serach_strategy` and ran with defaults instead of raising — now removed so Python raises `TypeError`.
- **mclp's demand-warning exemption broken for list input** ([64027d3](../../commit/64027d3)): `objectives=["mclp"]` didn't match the exemption check (`"mclp"` as a literal string), so the warning fired anyway for list-form input.
- **Weight keys not truly case-insensitive** ([d363111](../../commit/d363111)): `solve()`'s validation accepted `"Demand"`/`"Equity"` case-insensitively, but the actual column resolution in `EvaluatedCombination` didn't, silently producing all-zero weights and a confusing "weights sum to zero" crash. Also fixed an adjacent bug where the "unrecognised weight key" error was unreachable for genuine typos.
- **Invalid/duplicate/empty `site_indices`/`site_names` accepted** ([495d846](../../commit/495d846)): a partially-invalid index list (one real, one nonexistent) silently evaluated a smaller solution than requested; duplicates silently collapsed; an explicit empty list bypassed the mutual-exclusivity check. All now validated up front with clear errors.
- **Out-of-bounds index error message reported the wrong value** ([cda8e7a](../../commit/cda8e7a)): copy-paste bug reported the max valid index twice instead of the indices actually attempted. (Effectively unreachable now given the validation above; no test added — would require monkeypatching pandas' `.iloc`.)

## Plots

- **Equity plot titles rendered raw `np.int64(0)` reprs** ([0f6cdcc](../../commit/0f6cdcc)): titles now join site indices into a readable string, with an optional `show_site_names=True` to list names instead.

## Tests & docs

- Added a backtest suite (`tests/test_backtests.py`, `tests/backtest_snapshots.json`) and expanded `tests/conftest.py` fixtures.
- Documented test conventions in `tests/README.md`.
- Added `CLAUDE.md` with commit-workflow and fix-scope guidance for future AI-assisted changes.

## Test plan

- [x] `pytest` — full suite, including new regression tests for every fix above
- [x] For the direction-sensitive fixes (equity weighting, cost-weight no-op, `keep_best_n`/`keep_worst_n`), each fix was verified by reverting and confirming the new test fails before restoring
